### PR TITLE
Add config for EFO phenotypes

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -41,6 +41,9 @@ annotations:
   - uri: https://storage.googleapis.com/atlas_baseline_expression/expatlas.blueprint2.baseline.z-score.binned_v2.tsv
     output_filename: expatlas.blueprint2.baseline.z-score.binned_v2-{suffix}.tsv
     resource: hpa-rna-zscore
+  - uri: https://raw.githubusercontent.com/opentargets/data_pipeline/master/mrtarget/resources/eco_scores.tsv
+    output_filename: eco_scores-{suffix}.tsv
+    resource: eco-scores
 annotations_from_buckets:
   gs_output_dir: annotation-files
   downloads:

--- a/config.yaml
+++ b/config.yaml
@@ -41,9 +41,24 @@ annotations:
   - uri: https://storage.googleapis.com/atlas_baseline_expression/expatlas.blueprint2.baseline.z-score.binned_v2.tsv
     output_filename: expatlas.blueprint2.baseline.z-score.binned_v2-{suffix}.tsv
     resource: hpa-rna-zscore
-  - uri: https://raw.githubusercontent.com/opentargets/data_pipeline/master/mrtarget/resources/eco_scores.tsv
-    output_filename: eco_scores-{suffix}.tsv
-    resource: eco-scores
+  - uri: https://sourceforge.net/p/efo/code/HEAD/tree/trunk/src/efoassociations/ibd_2_pheno_associations.owl?format=raw
+    output_filename: ibd_2_pheno_associations-{suffix}.owl
+    resource: disease-phenotype
+  - uri: https://sourceforge.net/p/efo/code/HEAD/tree/trunk/src/efoassociations/immune_disease_2_pheno.owl?format=raw
+    output_filename: immune_disease_2_pheno-{suffix}.owl
+    resource: disease-phenotype
+  - uri: https://sourceforge.net/p/efo/code/HEAD/tree/trunk/src/efoassociations/rareAlbuminuria_associations_03Jun15.owl?format=raw
+    output_filename: rareAlbuminuria_associations_03Jun15-{suffix}.owl
+    resource: disease-phenotype
+  - uri: https://sourceforge.net/p/efo/code/HEAD/tree/trunk/src/efoassociations/rareIBDpheno.owl?format=raw
+    output_filename: rareIBDpheno-{suffix}.owl
+    resource: disease-phenotype
+  - uri: https://sourceforge.net/p/efo/code/HEAD/tree/trunk/src/efoassociations/ordo_hpo_mappings.owl?format=raw
+    output_filename: ordo_hpo_mappings-{suffix}.owl
+    resource: disease-phenotype
+  - uri: https://sourceforge.net/p/efo/code/HEAD/tree/trunk/src/efoassociations/charite_HP_ORDO_07Oct15.owl?format=raw
+    output_filename: charite_HP_ORDO_07Oct15-{suffix}.owl
+    resource: disease-phenotype
 annotations_from_buckets:
   gs_output_dir: annotation-files
   downloads:


### PR DESCRIPTION
annotation resource name is disease-phenotypes. 5 separate URLs.

Closes https://github.com/opentargets/platform/issues/389