### PR TITLE
Update chembl molecule

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -117,7 +117,7 @@ ChEMBL:
     molecule:
       uri: https://www.ebi.ac.uk/chembl/api/data/molecule.json
       output_filename: chembl_molecule_rest_api-{suffix}.json
-      resource: chembl-molecule-set-uri-pattern
+      resource: chembl-molecule
     target:
       uri: https://www.ebi.ac.uk/chembl/api/data/target.json
       output_filename: chembl_target_rest_api-{suffix}.json


### PR DESCRIPTION
Update the field name used for the chembl moleucle endpoint to match work on data_pipeline branch af-drug. This PR shouldn't be merged until that branch is completed and merged into data_pipeline master.