### PR TITLE
Post 2202 update

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -310,7 +310,7 @@ target:
     output_filename: cosmic-hallmarks-{suffix}.tsv.gz
     path: target-inputs/hallmarks
     includes: hallmarks
-  - bucket: otar001-core/TEPs/data_files
+  - bucket: otar001-core/TEPs
     output_filename: tep-{suffix}.json.gz
     path: target-inputs/tep
   - bucket: otar001-core/ChemicalProbes/annotation

--- a/config.yaml
+++ b/config.yaml
@@ -256,7 +256,7 @@ interactions:
 mousephenotypes:
   gs_downloads_latest:
   - bucket: otar001-core/MousePhenotypes
-    output_filename: mousePhenotypes-{suffix}.json.gz
+    output_filename: mouse_phenotypes-{suffix}.json.gz
     path: mouse-phenotypes-inputs
 openfda:
   http_downloads:

--- a/config.yaml
+++ b/config.yaml
@@ -139,7 +139,7 @@ evidence:
     output_spark_dir: genetics-portal-evidences-{suffix}
     path: evidence-files
   - bucket: otar010-atlas
-    output_filename: atlas-{suffix}.json.gz
+    output_filename: atlas-{suffix}.json.bz2
     output_spark_dir: atlas-{suffix}
     path: evidence-files
   - bucket: otar011-uniprot

--- a/plugins/helpers/EFO.py
+++ b/plugins/helpers/EFO.py
@@ -209,6 +209,7 @@ class EFO(object):
         elif (simple_id.group() in 'Orphanet_'):
             return "http://www.orpha.net/ORDO/"
         else:
+            logger.error("Match fail for {}".format(id))
             return "http://purl.obolibrary.org/obo/"
 
     def extract_id_from_uri(self, uri):


### PR DESCRIPTION
Resolves some minor issues identified during last platform release, mainly around data paths.

Updates:
- mouse phenotypes
- expression atlas
- tep

Adds a logging statement which I'd used to help figure out why were we getting bad EFOs in the disease data. 