### PR TITLE
Remove Timestamps from downloaded data

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -244,13 +244,13 @@ interactions:
     output_filename: HUMAN_9606_idmapping.dat.gz
     path: interactions-inputs
   - uri : ftp://ftp.ebi.ac.uk/pub/databases/intact/various/ot_graphdb/current/data/interactor_pair_interactions.json
-    output_filename: intact-interactors-{suffix}.json
+    output_filename: intact-interactors.json
     path: interactions-inputs
   http_downloads:
   - uri: https://stringdb-static.org/download/protein.links.detailed.v11.5/9606.protein.links.detailed.v11.5.txt.gz
-    output_filename: string-interactions-{suffix}.json.gz
+    output_filename: string-interactions.json.gz
     path: interactions-inputs
-  - uri: http://ftp.ensembl.org/pub/current_gtf/homo_sapiens/Homo_sapiens.GRCh38.105.chr.gtf.gz
+  - uri: http://ftp.ensembl.org/pub/current_gtf/homo_sapiens/Homo_sapiens.GRCh38.106.chr.gtf.gz
     output_filename: Homo_sapiens.GRCh38.chr.gtf.gz
     path: interactions-inputs
 mousephenotypes:

--- a/config.yaml
+++ b/config.yaml
@@ -8,11 +8,11 @@ disease:
   etl:
    hpo_phenotypes:
     uri: http://purl.obolibrary.org/obo/hp/hpoa/phenotype.hpoa
-    output_filename: hpo-phenotypes-{suffix}.jsonl
+    output_filename: hpo-phenotypes.jsonl
     path: ontology-inputs
    efo:
-    uri: https://github.com/EBISPOT/efo/releases/download/v3.40.0/efo_otar_slim.owl
-    output_filename: ontology-efo-v3.40.0.jsonl
+    uri: https://github.com/EBISPOT/efo/releases/download/v3.42.0/efo_otar_slim.owl
+    output_filename: ontology-efo-v3.42.0.jsonl
     path: ontology-inputs
     owl_jq: '.["@graph"][] | select (.["@type"] == ("Class","Restriction") and ."@id" != null)|.subClassOf=([.subClassOf]|flatten|del(.[]|nulls))|.hasExactSynonym=([.hasExactSynonym]|flatten|del(.[]|nulls))|.hasDbXref=([.hasDbXref]|flatten|del(.[]|nulls))|.inSubset=([.inSubset]|flatten|del(.[]|nulls))|.hasAlternativeId=([.hasAlternativeId]|flatten|del(.[]|nulls))|@json'
     diseases_static_file: diseases_efo.jsonl

--- a/config.yaml
+++ b/config.yaml
@@ -218,7 +218,7 @@ go:
 homologues:
   uri: ftp://ftp.ensembl.org/pub/release-{release}/json/
   path: target-inputs/homologue
-  release: 105
+  release: 106
   jq: ".genes[] | [.id, .name] | @tsv"
   resources:
       - 'caenorhabditis_elegans'

--- a/config.yaml
+++ b/config.yaml
@@ -34,7 +34,7 @@ drug:
      output_filename: 'drugbank_vocabulary.csv'
   gs_downloads_latest:
    - bucket: otar001-core/DrugBank/annotation
-     output_filename: drugbank-{suffix}.csv.gz
+     output_filename: drugbank.csv.gz
      path: chembl-inputs
   etl:
     chembl:

--- a/config.yaml
+++ b/config.yaml
@@ -189,26 +189,26 @@ evidence:
 expression:
   http_downloads:
   - uri: https://raw.githubusercontent.com/opentargets/expression_hierarchy/master/process/curation.tsv
-    output_filename: expression_hierarchy_curation-{suffix}.tsv
+    output_filename: expression_hierarchy_curation.tsv
     path: expression-inputs
   gs_downloads_latest:
   - bucket: atlas_baseline_expression/baseline_expression_binned
-    output_filename: baseline_expression_binned-{suffix}.tsv
+    output_filename: baseline_expression_binned.tsv
     path: expression-inputs
   - bucket: atlas_baseline_expression/baseline_expression_counts
-    output_filename: baseline_expression_counts-{suffix}.tsv
+    output_filename: baseline_expression_counts.tsv
     path: expression-inputs
   - bucket: atlas_baseline_expression/baseline_expression_zscore_binned
-    output_filename: baseline_expression_zscore_binned-{suffix}.tsv
+    output_filename: baseline_expression_zscore_binned.tsv
     path: expression-inputs
   etl:
     tissue_translation_map:
       uri: https://raw.githubusercontent.com/opentargets/expression_hierarchy/master/process/map_with_efos.json
-      output_filename: tissue-translation-map-{suffix}.json
+      output_filename: tissue-translation-map.json
       path: expression-inputs
     normal_tissues:
       uri: https://www.proteinatlas.org/download/normal_tissue.tsv.zip
-      output_filename: normal_tissue-{suffix}.tsv.gz
+      output_filename: normal_tissue.tsv.gz
       path: expression-inputs
 go:
   http_downloads:

--- a/config.yaml
+++ b/config.yaml
@@ -4,6 +4,8 @@ config:
   riot: /usr/share/apache-jena/bin/riot
   jq: /usr/bin/jq
   java_vm: -Xmx6096M
+  manifest:
+    file_name: "manifest.json"
 disease:
   etl:
    hpo_phenotypes:

--- a/config.yaml
+++ b/config.yaml
@@ -106,85 +106,85 @@ drug:
 evidence:
   gs_downloads_latest:
   - bucket: otar000-evidence_input/CancerBiomarkers/json
-    output_filename: cancerbiomarkers-{suffix}.json.gz
-    output_spark_dir: cancerbiomarkers-{suffix}
+    output_filename: cancerbiomarkers.json.gz
+    output_spark_dir: cancerbiomarkers
     path: evidence-files
   - bucket: otar000-evidence_input/Orphanet/json
-    output_filename: orphanet-{suffix}.json.gz
-    output_spark_dir: orphanet-{suffix}
+    output_filename: orphanet.json.gz
+    output_spark_dir: orphanet
     path: evidence-files
   - bucket: otar000-evidence_input/ClinGen/json
-    output_filename: clingen-{suffix}.json.gz
-    output_spark_dir: clingen-{suffix}
+    output_filename: clingen.json.gz
+    output_spark_dir: clingen
     path: evidence-files
   - bucket: otar000-evidence_input/CRISPR/json
-    output_filename: crispr-{suffix}.json.gz
-    output_spark_dir: crispr-{suffix}
+    output_filename: crispr.json.gz
+    output_spark_dir: crispr
     path: evidence-files
   - bucket: otar006-reactome
-    output_filename: reactome-{suffix}.json.gz
-    output_spark_dir: reactome-{suffix}
+    output_filename: reactome.json.gz
+    output_spark_dir: reactome
     path: evidence-files
   - bucket: otar007-cosmic
-    output_filename: cosmic-{suffix}.json.gz
-    output_spark_dir: cosmic-{suffix}
+    output_filename: cosmic.json.gz
+    output_spark_dir: cosmic
     excludes: hallmarks
     path: evidence-files
   - bucket: otar000-evidence_input/ChEMBL/json
-    output_filename: chembl-{suffix}.json.gz
-    output_spark_dir: chembl-{suffix}
+    output_filename: chembl.json.gz
+    output_spark_dir: chembl
     path: evidence-files
   - bucket: otar000-evidence_input/Genetics_portal/json/
-    output_filename: genetics-portal-evidences-{suffix}.json.gz
-    output_spark_dir: genetics-portal-evidences-{suffix}
+    output_filename: genetics-portal-evidences.json.gz
+    output_spark_dir: genetics-portal-evidences
     path: evidence-files
   - bucket: otar010-atlas
-    output_filename: atlas-{suffix}.json.bz2
-    output_spark_dir: atlas-{suffix}
+    output_filename: atlas.json.bz2
+    output_spark_dir: atlas
     path: evidence-files
   - bucket: otar011-uniprot
-    output_filename: uniprot-{suffix}.json.gz
-    output_spark_dir: uniprot-{suffix}
+    output_filename: uniprot.json.gz
+    output_spark_dir: uniprot
     path: evidence-files
   - bucket: otar012-eva
-    output_filename: eva-{suffix}.json.gz
-    output_spark_dir: eva-{suffix}
+    output_filename: eva.json.gz
+    output_spark_dir: eva
     path: evidence-files
   - bucket: otar000-evidence_input/EPMC/json
-    output_filename: epmc-{suffix}.json.gz
-    output_spark_dir: epmc-{suffix}
+    output_filename: epmc.json.gz
+    output_spark_dir: epmc
     path: evidence-files
   - bucket: otar000-evidence_input/Gene2Phenotype/json
-    output_filename: gene2phenotype-{suffix}.json.gz
-    output_spark_dir: gene2phenotype-{suffix}
+    output_filename: gene2phenotype.json.gz
+    output_spark_dir: gene2phenotype
     path: evidence-files
   - bucket: otar000-evidence_input/GenomicsEngland/json
-    output_filename: genomics_england-{suffix}.json.gz
-    output_spark_dir: genomics-england-{suffix}
+    output_filename: genomics_england.json.gz
+    output_spark_dir: genomics-england
     path: evidence-files
   - bucket: otar000-evidence_input/IntOgen/json
-    output_filename: intogen-{suffix}.json.gz
-    output_spark_dir: intogen-{suffix}
+    output_filename: intogen.json.gz
+    output_spark_dir: intogen
     path: evidence-files
   - bucket: otar000-evidence_input/IMPC/json
-    output_filename: impc-{suffix}.json.gz
-    output_spark_dir: impc-{suffix}
+    output_filename: impc.json.gz
+    output_spark_dir: impc
     path: evidence-files
   - bucket: otar000-evidence_input/PROGENy/json
-    output_filename: progeny-{suffix}.json.gz
-    output_spark_dir: progeny-{suffix}
+    output_filename: progeny.json.gz
+    output_spark_dir: progeny
     path: evidence-files
   - bucket: otar000-evidence_input/SLAPEnrich/json
-    output_filename: slapenrich-{suffix}.json.gz
-    output_spark_dir: slapenrich-{suffix}
+    output_filename: slapenrich.json.gz
+    output_spark_dir: slapenrich
     path: evidence-files
   - bucket: otar000-evidence_input/SysBio/json
-    output_filename: sysbio-{suffix}.json.gz
-    output_spark_dir: sysbio-{suffix}
+    output_filename: sysbio.json.gz
+    output_spark_dir: sysbio
     path: evidence-files
   - bucket: otar000-evidence_input/GeneBurden/json
-    output_filename: gene_burden-{suffix}.json.gz
-    output_spark_dir: gene_burden-{suffix}
+    output_filename: gene_burden.json.gz
+    output_spark_dir: gene_burden
     path: evidence-files
 expression:
   http_downloads:

--- a/config.yaml
+++ b/config.yaml
@@ -256,7 +256,7 @@ interactions:
 mousephenotypes:
   gs_downloads_latest:
   - bucket: otar001-core/MousePhenotypes
-    output_filename: mouse_phenotypes-{suffix}.json.gz
+    output_filename: mouse_phenotypes.json.gz
     path: mouse-phenotypes-inputs
 openfda:
   http_downloads:

--- a/config.yaml
+++ b/config.yaml
@@ -271,10 +271,10 @@ openfda:
 reactome:
   http_downloads:
   - uri: https://reactome.org/download/current/ReactomePathways.txt
-    output_filename: ReactomePathways-{suffix}.txt
+    output_filename: ReactomePathways.txt
     path: reactome-inputs
   - uri: https://reactome.org/download/current/ReactomePathwaysRelation.txt
-    output_filename: ReactomePathwaysRelation-{suffix}.txt
+    output_filename: ReactomePathwaysRelation.txt
     path: reactome-inputs
 so:
   etl:

--- a/config.yaml
+++ b/config.yaml
@@ -285,54 +285,54 @@ so:
 target:
   http_downloads:
   - uri: http://ftp.ebi.ac.uk/pub/databases/genenames/new/json/hgnc_complete_set.json
-    output_filename: hgnc_complete_set-{suffix}.json
+    output_filename: hgnc_complete_set.json
     path: target-inputs/genenames
   - uri: https://reactome.org/download/current/Ensembl2Reactome.txt
     output_filename: Ensembl2Reactome.txt
     path: target-inputs/reactome
   - uri: http://ftp.ebi.ac.uk/pub/databases/genenames/hcop/human_all_hcop_sixteen_column.txt.gz
-    output_filename: human_all_hcop_sixteen_column-{suffix}.txt.gz
+    output_filename: human_all_hcop_sixteen_column.txt.gz
     path: target-inputs/genenames
   - uri: https://cog.sanger.ac.uk/cmp/download/gene_identifiers_latest.csv.gz
     output_filename: gene_identifiers_latest.csv.gz
     path: target-inputs/project-scores
   - uri: https://www.uniprot.org/uniprot/?query=reviewed%3Ayes%2BAND%2Borganism%3A9606&compress=yes&format=txt
-    output_filename: uniprot-{suffix}.txt.gz
+    output_filename: uniprot.txt.gz
     path: target-inputs/uniprot
   - uri: https://www.uniprot.org/locations/?query=*&format=tab&force=true&columns=id&compress=yes
-    output_filename: uniprot-ssl-{suffix}.tsv.gz
+    output_filename: uniprot-ssl.tsv.gz
     path: target-inputs/uniprot
   gs_downloads_latest:
   - bucket: otar001-core/subcellularLocations
-    output_filename: subcellular_locations_ssl-{suffix}.tsv
+    output_filename: subcellular_locations_ssl.tsv
     path: target-inputs/hpa
   - bucket: otar007-cosmic
-    output_filename: cosmic-hallmarks-{suffix}.tsv.gz
+    output_filename: cosmic-hallmarks.tsv.gz
     path: target-inputs/hallmarks
     includes: hallmarks
   - bucket: otar001-core/TEPs
-    output_filename: tep-{suffix}.json.gz
+    output_filename: tep.json.gz
     path: target-inputs/tep
   - bucket: otar001-core/ChemicalProbes/annotation
-    output_filename: chemicalprobes-{suffix}.json
+    output_filename: chemicalprobes.json
     path: target-inputs/chemicalprobes
   - bucket: otar001-core/TargetSafety/data_files/adverse_events
-    output_filename: adverse_event_safety-{suffix}.json
+    output_filename: adverse_event_safety.json
     path: target-inputs/safety/adverse_events
   - bucket: otar001-core/TargetSafety/data_files/safety_risk/
-    output_filename: sr-{suffix}.json
+    output_filename: sr.json
     path: target-inputs/safety/safety_risk
   - bucket: otar001-core/TargetSafety/data_files/toxcast/
-    output_filename: ToxCast-{suffix}.tsv
+    output_filename: ToxCast.tsv
     path: target-inputs/safety/toxcast
   - bucket: otar001-core/Tractability
-    output_filename: tractability-{suffix}.tsv
+    output_filename: tractability.tsv
     path: target-inputs/tractability
   ftp_downloads:
-  - uri: ftp://ftp.ensembl.org/pub/release-105/tsv/ensembl-compara/homologies/homo_sapiens/Compara.105.protein_default.homologies.tsv.gz
+  - uri: ftp://ftp.ensembl.org/pub/release-106/tsv/ensembl-compara/homologies/homo_sapiens/Compara.106.protein_default.homologies.tsv.gz
     output_filename: cpd.tsv.gz
     path: target-inputs/homologue
-  - uri: ftp://ftp.ensembl.org/pub/release-105/tsv/ensembl-compara/homologies/homo_sapiens/Compara.105.ncrna_default.homologies.tsv.gz
+  - uri: ftp://ftp.ensembl.org/pub/release-106/tsv/ensembl-compara/homologies/homo_sapiens/Compara.106.ncrna_default.homologies.tsv.gz
     output_filename: crna.tsv.gz
     path: target-inputs/homologue
   - uri: ftp://ftp.ebi.ac.uk/pub/databases/RNAcentral/current_release/id_mapping/database_mappings/ensembl.tsv

--- a/manifest/__init__.py
+++ b/manifest/__init__.py
@@ -1,0 +1,2 @@
+from .models import *
+from .services import get_manifest_service, ManifestServiceException, ManifestService

--- a/manifest/models.py
+++ b/manifest/models.py
@@ -1,9 +1,32 @@
 # Manifest file Models
+import time
+import typing
 
 # TODO - Global Data model
-class Manifest:
+class ManifestDocument:
     def __init__(self):
-        pass
+        """
+        Constructor for the Manifest file root content
+        """
+        timestamp :float = time.time()
+        self.created :float = timestamp
+        self.modified :float = timestamp
+        self.steps :typing.Dict[str, ManifestStep] = dict()
 
 # TODO - Step Data model
+class ManifestStep:
+    def __init__(self):
+        timestamp :float = time.time()
+        self.created :float = timestamp
+        self.modified :float = timestamp
+        self.steps = typing.Dict[str, ManifestResource]
+
 # TODO - Resource data model
+class ManifestResource:
+    def __init__(self):
+        timestamp :float = time.time()
+        self.created :float = timestamp
+        self.modified :float = timestamp
+        self.source_url :str = "NOT SPECIFIED"
+        self.path_destination :str = "NOT SPECIFIED"
+        self.checksum :str = "NOT SPECIFIED"

--- a/manifest/models.py
+++ b/manifest/models.py
@@ -1,6 +1,10 @@
 # Manifest file Models
 import time
 import typing
+import logging
+
+# Logging
+logger = logging.getLogger(__name__)
 
 # TODO - Global Data model
 class ManifestDocument:
@@ -9,6 +13,7 @@ class ManifestDocument:
         Constructor for the Manifest file root content
         """
         timestamp :float = time.time()
+        self.session :float = timestamp
         self.created :float = timestamp
         self.modified :float = timestamp
         self.steps :typing.Dict[str, ManifestStep] = dict()
@@ -19,7 +24,8 @@ class ManifestStep:
         timestamp :float = time.time()
         self.created :float = timestamp
         self.modified :float = timestamp
-        self.steps = typing.Dict[str, ManifestResource]
+        self.step :str = "NOT SPECIFIED"
+        self.steps :typing.Dict[str, ManifestResource] = dict()
 
 # TODO - Resource data model
 class ManifestResource:

--- a/manifest/models.py
+++ b/manifest/models.py
@@ -1,0 +1,9 @@
+# Manifest file Models
+
+# TODO - Global Data model
+class Manifest:
+    def __init__(self):
+        pass
+
+# TODO - Step Data model
+# TODO - Resource data model

--- a/manifest/services.py
+++ b/manifest/services.py
@@ -1,0 +1,75 @@
+import os
+import time
+import json
+import logging
+from .models import ManifestStep, ManifestResource, ManifestDocument
+
+# Logging
+logger = logging.getLogger(__name__)
+
+# Singleton
+__manifestServiceInstance = None
+
+
+def get_manifest_service(args=None, configuration=None):
+    global __manifestServiceInstance
+    if __manifestServiceInstance is None:
+        if configuration is None:
+            msg = "The Manifest subsystem has not been initialized and no configuration has been provided"
+            logger.error(msg)
+            raise ManifestServiceException(msg)
+        else:
+            manifest_config = configuration.config.manifest
+            manifest_config.update({"output_dir": args.output_dir})
+            logger.debug("Initializing Manifest service, configuration: {}".format(json.dumps(manifest_config)))
+            __manifestServiceInstance = ManifestService(manifest_config)
+    return __manifestServiceInstance
+
+
+class ManifestServiceException(Exception):
+    """
+    Exception type for errors dealing with the manifest file
+    """
+    pass
+
+
+class ManifestService:
+    """
+    This service manages the session's Manifest file
+    """
+
+    def __init__(self, config):
+        self.__manifest :ManifestDocument = None
+        self.config = config
+        self.session_timestamp :float = time.time()
+        # TODO
+
+    def __create_manifest(self) -> ManifestDocument:
+        manifest_document = ManifestDocument()
+        manifest_document.session = self.session_timestamp
+        return manifest_document
+
+    def __load_or_create_manifest(self) -> ManifestDocument:
+        self.__manifest = self.__create_manifest()
+        # TODO Option - Copy from remote
+        # TODO Overwrite with locally
+        pass
+
+    @property
+    def path_manifest(self) -> str:
+        return os.path.join(self.config.output_dir, self.config.file_name)
+
+    @property
+    def manifest(self) -> ManifestDocument:
+        if self.__manifest is None:
+            self.__manifest = self.__load_or_create_manifest()
+        return self.__manifest
+
+    def get_step(self, step_name: str) -> ManifestStep:
+        pass
+
+    def create_resource(self) -> ManifestResource:
+        pass
+
+    def persist(self):
+        pass

--- a/platform-input-support.py
+++ b/platform-input-support.py
@@ -3,6 +3,7 @@ import logging.config
 
 # Custom modules
 import modules.cfg as cfg
+import manifest
 from modules.common.YAMLReader import YAMLReader
 from modules.RetrieveResource import RetrieveResource
 
@@ -26,6 +27,9 @@ def main():
     print_list_steps(yaml.get_list_keys())
     cfg.set_up_logging(args)
 
+    # Session's Manifest
+    manifest_service = manifest.get_manifest_service(args, yaml_dict)
+    # Resources retriever
     resources = RetrieveResource(args, yaml_dict)
     resources.run()
 

--- a/plugins/Drug.py
+++ b/plugins/Drug.py
@@ -20,7 +20,6 @@ class Drug(IPlugin):
         Constructor, prepare logging subsystem and time stamp
         """
         self._logger = logging.getLogger(__name__)
-        self.write_date = datetime.today().strftime('%Y-%m-%d')
 
     def _download_elasticsearch_data(self, output_dir, url, port, indices):
         """
@@ -37,7 +36,7 @@ class Drug(IPlugin):
         if elasticsearch_reader.is_reachable():
             for index in list(indices.values()):
                 index_name = index['name']
-                outfile = os.path.join(output_dir, "{}-{}.jsonl".format(index_name, self.write_date))
+                outfile = os.path.join(output_dir, "{}.jsonl".format(index_name))
 
                 logger.info("Downloading Elasticsearch data from index {}, to file '{}'".format(index_name, outfile))
                 docs_saved = elasticsearch_reader.get_fields_on_index(index_name, outfile, index['fields'])


### PR DESCRIPTION
This PR removes all the timestamps either embedded by PIS in the produced files, or coming from the data source where PIS got the data from.
It also contains the initial draft for the _manifest file_ data models, a feature that although being a work in progress, doesn't interfere with the removal of the timestamps.

