### PR TITLE
Pull ChEMBL data from outside the EBI

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,9 +366,6 @@ The Drug step is used to gather the raw data for the [platform ETL](https://gith
 ChEMBL have made an Elasticsearch instance available for querying. To keep data volumes and running times down specify the
 index and fields which are required in the config file.
 
-ChEMBL's ES instance is only available from within the EMBL-EBI VPN. If you need to run this step it is necessary that you
-use a machine that is connected to the VPN network. 
-
 ## Homology Step
 
 This step is used to download raw json data from the ENSEMBL [ftp server](https://ftp.ensembl.org/pub/current_json/) for 

--- a/config.yaml
+++ b/config.yaml
@@ -41,8 +41,8 @@ drug:
   etl:
     chembl:
       type: elasticsearch
-      url: hh-rke-wp-webadmin-04-worker-4.caas.ebi.ac.uk
-      port: 32000
+      url: https://www.ebi.ac.uk/chembl/elk/es
+      port: 80
       path: chembl-inputs
       indices:
         chembl-indication:

--- a/config.yaml
+++ b/config.yaml
@@ -42,7 +42,6 @@ drug:
     chembl:
       type: elasticsearch
       url: https://www.ebi.ac.uk/chembl/elk/es
-      port: 80
       path: chembl-inputs
       indices:
         chembl-indication:

--- a/modules/common/ElasticsearchHelper.py
+++ b/modules/common/ElasticsearchHelper.py
@@ -14,7 +14,7 @@ class ElasticsearchInstance(object):
     Wrapper over an Elasticsearch instance.
     """
 
-    def __init__(self, host, port, scheme='http'):
+    def __init__(self, url=None, host=None, port=None, scheme='http'):
         """
         Constructor
 
@@ -25,12 +25,20 @@ class ElasticsearchInstance(object):
         self._port = port
         self._host = host
         self._scheme = scheme
-        logger.info("Creating Elastic Search Instance Wrapper with host: {}, port: {}".format(self._host, self._port))
-        self.es = Elasticsearch([{'host': self._host, 'port': self._port}])
+        self._url = url
+        self._es = None
 
     @property
-    def es_url(self):
-        return "{}://{}:{}".format(self._scheme, self._host, self._port)
+    def url(self):
+        if self._url is None:
+            return "{}://{}:{}".format(self._scheme, self._host, self._port)
+        return self._url
+
+    @property
+    def es(self):
+        if self._es is None:
+            self._es = Elasticsearch(self.url)
+        return self._es
 
     def is_reachable(self):
         """
@@ -39,10 +47,10 @@ class ElasticsearchInstance(object):
         :return: true if reachable, false otherwise
         """
         try:
-            request = requests.head(self.es_url, timeout=1)
+            request = requests.head(self.url, timeout=1)
             return request.ok
         except ConnectionError as error:
-            logger.error("Unable to reach {}. Error msg: ".format(self.es_url, error))
+            logger.error("Unable to reach {}. Error msg: ".format(self.url, error))
         return False
 
     @staticmethod

--- a/plugins/Drug.py
+++ b/plugins/Drug.py
@@ -63,10 +63,7 @@ class Drug(IPlugin):
         :return: list of files downloaded.
         """
 
-        if source.url is not None \
-                and source.port is not None \
-                and isinstance(source.url, str) \
-                and isinstance(source.port, int):
+        if source.url is not None and isinstance(source.url, str):
             logger.info("{} indices found for {}.".format(len(source.indices), source))
             return self._download_elasticsearch_data(output_dir, source.url, source.indices)
         logger.error("Unable to validate host and port for Elasticsearch connection.")

--- a/plugins/Drug.py
+++ b/plugins/Drug.py
@@ -21,18 +21,17 @@ class Drug(IPlugin):
         """
         self._logger = logging.getLogger(__name__)
 
-    def _download_elasticsearch_data(self, output_dir, url, port, indices):
+    def _download_elasticsearch_data(self, output_dir, url, indices):
         """
         Query elasticsearchReader for each index specified in indices and saves results as jsonl files at output_dir.
 
         :param output_dir: output folder
         :param url: Elastic Search URL
-        :param port: Elastic Search port
         :param indices: indices for querying Elastic Search
         :return: list of files successfully saved.
         """
         results = []
-        elasticsearch_reader = ElasticsearchInstance(url, port)
+        elasticsearch_reader = ElasticsearchInstance(url)
         if elasticsearch_reader.is_reachable():
             for index in list(indices.values()):
                 index_name = index['name']
@@ -49,9 +48,9 @@ class Drug(IPlugin):
                 results.append(outfile)
         else:
             logger.error("Unable to reach ChEMBL Elasticsearch! "
-                         "at URL '{}', port '{}' Cannot collect necessary data.".format(url, port))
+                         "at URL '{}', Cannot collect necessary data.".format(url))
             warnings.warn("ChEMBL Elasticsearch is unreachable: "
-                          "URL '{}', port '{}', check network settings.".format(url, port))
+                          "URL '{}', check network settings.".format(url))
         return results
 
     # TODO We should refactor this out into a generic Elastic Search Helper
@@ -69,7 +68,7 @@ class Drug(IPlugin):
                 and isinstance(source.url, str) \
                 and isinstance(source.port, int):
             logger.info("{} indices found for {}.".format(len(source.indices), source))
-            return self._download_elasticsearch_data(output_dir, source.url, source.port, source.indices)
+            return self._download_elasticsearch_data(output_dir, source.url, source.indices)
         logger.error("Unable to validate host and port for Elasticsearch connection.")
         return []
 


### PR DESCRIPTION
This PR changes the way we collect ChEMBL data, so we no longer need to do it from within the internal infrastructure.
It solves opentargets/issues#2646.