### PR TITLE
Excessive logging reduction and levels revisited

### DIFF
--- a/modules/RetrieveResource.py
+++ b/modules/RetrieveResource.py
@@ -44,9 +44,10 @@ class RetrieveResource(object):
         Copy local files to the given Google Storage Bucket destination
         """
         if self.args.google_bucket is not None:
+            logger.info(f"Copying files to GCP bucket '{self.args.google_bucket}'")
             Utils(self.yaml.config, self.yaml.outputs).gsutil_multi_copy_to(self.args.google_bucket)
         else:
-            logger.error("Destination bucket info missing")
+            logger.warning("No GCP Bucket details provided, THE COLLECTED DATA WILL STAY LOCAL")
 
     def matching_steps(self, steps, all_plugins_available):
         """

--- a/modules/RetrieveResource.py
+++ b/modules/RetrieveResource.py
@@ -63,7 +63,7 @@ class RetrieveResource(object):
                 matching_plugins.append(plugin)
                 lowercase_steps.remove(plugin.lower())
 
-        logger.warning("Steps not found:\n" + ','.join(lowercase_steps))
+        logger.warning("Steps NOT FOUND:\n" + ','.join(lowercase_steps))
         return matching_plugins
 
     def steps(self):

--- a/modules/RetrieveResource.py
+++ b/modules/RetrieveResource.py
@@ -79,7 +79,7 @@ class RetrieveResource(object):
         else:
             plugins_to_run = list(set(steps_requested))
 
-        logger.info("Steps selected:\n" + ','.join(plugins_to_run))
+        logger.info("SELECTED Steps:\n" + ','.join(plugins_to_run))
         return plugins_to_run
 
     def init_plugins(self):

--- a/modules/RetrieveResource.py
+++ b/modules/RetrieveResource.py
@@ -123,7 +123,7 @@ class RetrieveResource(object):
         if self.args.force_clean:
             recursive_remove_folder(output_dir)
         else:
-            logger.info("Warning: Output not deleted.")
+            logger.warning("Output folder NOT CLEANED UP.")
         self.yaml.outputs.prod_dir = create_folder(os.path.join(output_dir, 'prod'))
         self.yaml.outputs.staging_dir = create_folder(os.path.join(output_dir, 'staging'))
 

--- a/modules/RetrieveResource.py
+++ b/modules/RetrieveResource.py
@@ -63,7 +63,7 @@ class RetrieveResource(object):
                 matching_plugins.append(plugin)
                 lowercase_steps.remove(plugin.lower())
 
-        logger.info("Steps not found:\n" + ','.join(lowercase_steps))
+        logger.warning("Steps not found:\n" + ','.join(lowercase_steps))
         return matching_plugins
 
     def steps(self):

--- a/modules/common/DownloadResource.py
+++ b/modules/common/DownloadResource.py
@@ -30,7 +30,7 @@ class DownloadResource(object):
 
     def __init__(self, output_dir):
         """
-        Constructor
+        Constructor.
 
         :param output_dir: path to download destination folder
         """
@@ -43,7 +43,7 @@ class DownloadResource(object):
 
     def set_filename(self, filename) -> str:
         """
-        Build final destination file path
+        Build final destination file path.
 
         :param filename: Base file name
         """

--- a/modules/common/DownloadResource.py
+++ b/modules/common/DownloadResource.py
@@ -66,13 +66,12 @@ class DownloadResource(object):
                     opener.addheaders = [('User-agent', 'Mozilla/5.0'), ('Accept', resource_info.accept)]
                 urllib.request.install_opener(opener)
                 destination_filename = self.set_filename(resource_info.output_filename)
-                with TqdmUpTo(unit='B', unit_scale=True, miniters=1,
-                              desc=resource_info.uri.split('/')[-1]) as t:  # all optional kwargs
-                    urllib.request.urlretrieve(resource_info.uri, destination_filename,
-                                               reporthook=t.update_to, data=None)
+                logger.info(f"[DOWNLOAD] START: '{resource_info.uri}' -> '{destination_filename}'")
+                urllib.request.urlretrieve(resource_info.uri, destination_filename)
+                logger.info(f"[DOWNLOAD] END: '{resource_info.uri}' -> '{destination_filename}'")
                 return destination_filename
             except urllib.error.URLError as e:
-                logger.error('Download error:', e.reason)
+                logger.error('[DOWNLOAD] ERROR:', e.reason)
                 try:
                     if 500 <= e.code < 600:
                         continue

--- a/modules/common/DownloadResource.py
+++ b/modules/common/DownloadResource.py
@@ -66,13 +66,14 @@ class DownloadResource(object):
                     opener.addheaders = [('User-agent', 'Mozilla/5.0'), ('Accept', resource_info.accept)]
                 urllib.request.install_opener(opener)
                 destination_filename = self.set_filename(resource_info.output_filename)
-                logger.info(f"[DOWNLOAD] START: '{resource_info.uri}' -> '{destination_filename}'")
+                logger.info(f"[DOWNLOAD] BEGIN: '{resource_info.uri}' -> '{destination_filename}'")
                 urllib.request.urlretrieve(resource_info.uri, destination_filename)
                 logger.info(f"[DOWNLOAD] END: '{resource_info.uri}' -> '{destination_filename}'")
                 return destination_filename
             except urllib.error.URLError as e:
                 logger.error('[DOWNLOAD] ERROR:', e.reason)
                 try:
+                    # TODO - This is useful information to report back to the caller
                     if 500 <= e.code < 600:
                         continue
                     break
@@ -100,8 +101,10 @@ class DownloadResource(object):
         print("Start to download\n\t{uri} ".format(uri=resource_info.uri))
         try:
             filename = self.set_filename(resource_info.output_filename)
+            logger.info(f"[DOWNLOAD] BEGIN: '{resource_info.uri}' -> '{filename}'")
             urllib.request.urlretrieve(resource_info.uri, filename)
             urllib.request.urlcleanup()
+            logger.info(f"[DOWNLOAD] END: '{resource_info.uri}' -> '{filename}'")
         except Exception:
             logger.warning("Warning: FTP! {}".format(resource_info.uri))
             # EBI FTP started to reply ConnectionResetError: [Errno 104] Connection reset by peer.

--- a/modules/common/DownloadResource.py
+++ b/modules/common/DownloadResource.py
@@ -106,12 +106,13 @@ class DownloadResource(object):
             urllib.request.urlcleanup()
             logger.info(f"[DOWNLOAD] END: '{resource_info.uri}' -> '{filename}'")
         except Exception:
-            logger.warning("Warning: FTP! {}".format(resource_info.uri))
+            logger.warning("[DOWNLOAD] Re-trying with a command line tool - '{}'".format(resource_info.uri))
             # EBI FTP started to reply ConnectionResetError: [Errno 104] Connection reset by peer.
             # I had an exchange of email with sysinfo, they suggested us to use wget.
             cmd = 'curl ' + resource_info.uri + ' --output ' + filename
-            logger.warning("wget attempt {}".format(cmd))
+            logger.warning("[DOWNLOAD] Re-try Command '{}'".format(cmd))
             # TODO We need to handle the completion of this command, I think it would be worth writing a handler helper
+            # TODO There is neither a timed wait nor a re-try strategy for this command
             p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
 
         return filename

--- a/modules/common/DownloadResource.py
+++ b/modules/common/DownloadResource.py
@@ -6,7 +6,6 @@ import subprocess
 import urllib.request, urllib.parse, urllib.error
 # Common packages
 from typing import Dict
-from modules.common.TqdmUpTo import TqdmUpTo
 
 logger = logging.getLogger(__name__)
 

--- a/modules/common/Downloads.py
+++ b/modules/common/Downloads.py
@@ -66,6 +66,7 @@ class Downloads(object):
 
         :param resources_info: information on the resources to download
         """
+        # TODO Those places where the download was not possible, need to report back to the caller.
         for resource in resources_info.ftp_downloads:
             try:
                 path = create_folder(os.path.join(self.path_root, resource.path))

--- a/modules/common/Downloads.py
+++ b/modules/common/Downloads.py
@@ -57,7 +57,7 @@ class Downloads(object):
         if google_resource.get_bucket() is not None:
             latest_filename = google_resource.get_latest_file(resource)
             if latest_filename["latest_filename"] is None:
-                logger.info(f"ERROR: The path={google_resource.bucket_name} does not contain any recent file")
+                logger.warning(f"The path={google_resource.bucket_name} does not contain any recent file")
         return latest_filename
 
     def exec(self, resources_info):

--- a/modules/common/Downloads.py
+++ b/modules/common/Downloads.py
@@ -62,7 +62,7 @@ class Downloads(object):
 
     def exec(self, resources_info):
         """
-        Download the resources according to their provided information
+        Download the resources according to their provided information.
 
         :param resources_info: information on the resources to download
         """
@@ -72,13 +72,13 @@ class Downloads(object):
                 download = DownloadResource(path)
                 download.ftp_download(resource)
             except Exception as e:
-                logger.error(f"ERROR: The resource={resource.uri} was not downloaded, '{e}'")
+                logger.error(f"COULD NOT DOWNLOAD resource '{resource.uri}', due to '{e}'")
 
         for resource in resources_info.http_downloads:
             try:
                 self.single_http_download(resource)
             except Exception as e:
-                logger.error(f"ERROR: The resource={resource.uri} was not downloaded, '{e}'")
+                logger.error(f"COULD NOT DOWNLOAD resource '{resource.uri}', due to '{e}'")
 
         for resource in resources_info.gs_downloads_latest:
             try:
@@ -88,7 +88,7 @@ class Downloads(object):
                 download_info = self.prepare_gs_download(latest_resource, resource)
                 google_resource.download(download_info)
             except Exception as e:
-                logger.error(f"ERROR: The resource={resource.bucket} was not downloaded, '{e}'")
+                logger.error(f"COULD NOT DOWNLOAD resource '{resource.bucket}', due to '{e}'")
 
     def single_http_download(self, resource):
         """

--- a/modules/common/Downloads.py
+++ b/modules/common/Downloads.py
@@ -18,7 +18,7 @@ class Downloads(object):
 
     def __init__(self, output_dir):
         """
-        Constructor
+        Constructor.
 
         :param output_dir: path to download destination folder
         """

--- a/modules/common/ElasticsearchHelper.py
+++ b/modules/common/ElasticsearchHelper.py
@@ -51,7 +51,7 @@ class ElasticsearchInstance(object):
             request = requests.head(self.url, timeout=1)
             return request.ok
         except ConnectionError as error:
-            logger.error("Unable to reach {}. Error msg: ".format(self.url, error))
+            logger.error("Unable to reach {}. Error msg: {}".format(self.url, error))
         return False
 
     @staticmethod

--- a/modules/common/ElasticsearchHelper.py
+++ b/modules/common/ElasticsearchHelper.py
@@ -91,7 +91,7 @@ class ElasticsearchInstance(object):
                 if f in hit:
                     hit_dict[f] = self._process_hit_value(hit[f])
                 else:
-                    logger.error("field \"%s\" not found on document from index: %s", f, index)
+                    logger.error("field \"%s\" NOT FOUND on document from index: %s", f, index)
             doc_buffer.append(hit_dict)
             # write buffer to file, update document count, and clear buffer
             if len(doc_buffer) >= size:

--- a/modules/common/ElasticsearchHelper.py
+++ b/modules/common/ElasticsearchHelper.py
@@ -31,7 +31,8 @@ class ElasticsearchInstance(object):
     @property
     def url(self):
         if self._url is None:
-            return "{}://{}:{}".format(self._scheme, self._host, self._port)
+            self._url = "{}://{}:{}".format(self._scheme, self._host, self._port)
+        logger.debug(f"Elastic Search Helper - URL '{self._url}'")
         return self._url
 
     @property

--- a/modules/common/ElasticsearchHelper.py
+++ b/modules/common/ElasticsearchHelper.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import requests
-
 from requests import ConnectionError
 from elasticsearch import Elasticsearch
 from elasticsearch_dsl import Search, utils

--- a/modules/common/ElasticsearchHelper.py
+++ b/modules/common/ElasticsearchHelper.py
@@ -7,6 +7,9 @@ from elasticsearch import Elasticsearch
 from elasticsearch_dsl import Search, utils
 
 logger = logging.getLogger(__name__)
+# Remove excessive logging for Elastic Search Library
+es_logger = logging.getLogger('elasticsearch')
+es_logger.setLevel(logging.WARNING)
 
 
 class ElasticsearchInstance(object):

--- a/modules/common/ElasticsearchHelper.py
+++ b/modules/common/ElasticsearchHelper.py
@@ -10,6 +10,9 @@ logger = logging.getLogger(__name__)
 # Remove excessive logging for Elastic Search Library
 es_logger = logging.getLogger('elasticsearch')
 es_logger.setLevel(logging.WARNING)
+# Remove excessive logging from urllib3 used by Elastic Search Library
+urllib_logger = logging.getLogger('urllib3.connectionpool')
+urllib_logger.setLevel(logging.WARNING)
 
 
 class ElasticsearchInstance(object):

--- a/modules/common/GoogleBucketResource.py
+++ b/modules/common/GoogleBucketResource.py
@@ -147,7 +147,7 @@ class GoogleBucketResource(object):
         """
         return self.list_blobs(self.object_path, include=included_pattern)
 
-    # WARNING - UNUSED - REMOVE - DEPRECATE
+    # TODO - UNUSED method, REMOVE
     def copy_from(self, original_filename, dest_filename, gs_specific_output_dir=None):
         bucket_link = self.get_bucket()
         if bucket_link is None:
@@ -277,6 +277,7 @@ class GoogleBucketResource(object):
             return self.download_dir(download_descriptor["file"], download_descriptor["output"])
         return self.download_file(download_descriptor["file"], download_descriptor["output"])
 
+    # TODO - UNUSED method, REMOVE
     def blob_metadata(self, blob_name):
         """
         Prints out a blob's metadata for the given BLOB name

--- a/modules/common/GoogleBucketResource.py
+++ b/modules/common/GoogleBucketResource.py
@@ -203,7 +203,7 @@ class GoogleBucketResource(object):
                     else:
                         # it is spark dir. Check if it is the same dir
                         if os.path.dirname(filename) != os.path.dirname(last_recent_file):
-                            logger.info("'{}' vs '{}'".format(filename, last_recent_file))
+                            logger.debug("'{}' vs '{}'".format(filename, last_recent_file))
                             possible_recent_date_collision = True
                 if date_file > recent_date:
                     possible_recent_date_collision = False

--- a/modules/common/GoogleBucketResource.py
+++ b/modules/common/GoogleBucketResource.py
@@ -89,9 +89,9 @@ class GoogleBucketResource(object):
                 bucket = self.client.get_bucket(self.bucket_name)
                 return bucket
             except google.cloud.exceptions.NotFound:
-                logger.error("Sorry, that bucket {} does not exist!".format(self.bucket_name))
+                logger.error("Bucket '{}' NOT FOUND".format(self.bucket_name))
             except exceptions.Forbidden:
-                logger.error(" ERROR: GCS forbidden access, path={}".format(self.bucket_name))
+                logger.error("Google Cloud Storage, FORBIDDEN access, path '{}'".format(self.bucket_name))
         return None
 
     # For instance you can call the method
@@ -158,7 +158,7 @@ class GoogleBucketResource(object):
             object_path = object_path + '/' + gs_specific_output_dir
 
         blob = bucket_link.blob(object_path + '/' + dest_filename)
-        logger.info('Copy the file %s to the bucket %s', original_filename, bucket_link)
+        logger.debug('Copy the file %s to the bucket %s', original_filename, bucket_link)
         if ".gz" in original_filename:
             blob.content_type = "application/x-gzip"
         else:

--- a/modules/common/Riot.py
+++ b/modules/common/Riot.py
@@ -58,6 +58,7 @@ class Riot(object):
                                      stdout=subprocess.PIPE) as jq_process:
                 json_output.write(jq_process.stdout.read())
         except EnvironmentError as e:
+            # TODO - Report back to caller
             logger.error("When running RIOT for OWL file '{}', "
                          "with destination path '{}' and JQ filter '{}', "
                          "the following error occurred: '{}'".format(owl_file, path_output, owl_jq, e))

--- a/modules/common/TqdmUpTo.py
+++ b/modules/common/TqdmUpTo.py
@@ -1,5 +1,6 @@
 from tqdm import tqdm
 
+# TODO UNUSED
 # TODO Flagged for removal
 class TqdmUpTo(tqdm):
     """Provides `update_to(n)` which uses `tqdm.update(delta_n)`."""

--- a/modules/common/TqdmUpTo.py
+++ b/modules/common/TqdmUpTo.py
@@ -1,5 +1,6 @@
 from tqdm import tqdm
 
+# TODO Flagged for removal
 class TqdmUpTo(tqdm):
     """Provides `update_to(n)` which uses `tqdm.update(delta_n)`."""
     def update_to(self, b=1, bsize=1, tsize=None):

--- a/modules/common/Utils.py
+++ b/modules/common/Utils.py
@@ -53,7 +53,7 @@ class Utils(object):
                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         # I know, magic numbers
         completed = False
-        for attempt in range(7):
+        for attempt in range(9):
             try:
                 # Wait for 1 hour for the operation to complete
                 _, err = proc.communicate(timeout=3600)

--- a/modules/common/Utils.py
+++ b/modules/common/Utils.py
@@ -28,7 +28,7 @@ class Utils(object):
         cmd_result = shutil.which(cmd)
         if cmd_result is None:
             cmd_result = yaml_cmd
-            logger.info("'{}' not found. Using the path from config.yaml".format(cmd))
+            logger.warning("Command '{}' NOT FOUND. Using the path from config.yaml".format(cmd))
         logger.debug(f"'{cmd}' path '{cmd_result}'")
         return cmd_result
 

--- a/modules/common/Utils.py
+++ b/modules/common/Utils.py
@@ -58,7 +58,7 @@ class Utils(object):
                 # Wait for 1 hour for the operation to complete
                 _, err = proc.communicate(timeout=3600)
             except subprocess.TimeoutExpired:
-                logger.error("Attempt #{} timed out!".format(attempt + 1))
+                logger.warning("Attempt #{} timed out!".format(attempt + 1))
                 continue
             except Exception as e:
                 proc.kill()
@@ -66,14 +66,14 @@ class Utils(object):
                 break
             else:
                 completed = True
-                logger.info("gsutil copy for source '{}', destination '{}' completed!"
+                logger.info("gsutil copy for source '{}', destination '{}' COMPLETED!"
                             .format(os.path.join(self.output_dir, "*"), "gs://{}/".format(destination_bucket)))
                 break
         if not completed:
             proc.kill()
             _, err = proc.communicate()
             logger.error(
-                f"Could not complete file copy to GCP Bucket '{destination_bucket}', error output '{err.decode('utf-8')}'")
+                f"COULD NOT COMPLETE file copy to GCP Bucket '{destination_bucket}', error output '{err.decode('utf-8')}'")
 
     @staticmethod
     def resource_for_stage(resource):

--- a/modules/common/YAMLReader.py
+++ b/modules/common/YAMLReader.py
@@ -33,6 +33,7 @@ class YAMLReader(object):
                 self.yaml_data = yaml.load(stream, yaml.SafeLoader)
                 self.yaml_dictionary = Dict(self.yaml_data)
             except yaml.YAMLError as e:
+                # TODO Report error back to caller
                 logger.error(f"The following ERROR occurred while reading YAML file '{self.yaml_file}', '{e}'")
         if standard_output:
             return self.yaml_data

--- a/modules/common/__init__.py
+++ b/modules/common/__init__.py
@@ -93,7 +93,7 @@ def recursive_remove_folder(folder):
     :return: the removed folder tree path if success, None otherwise
     """
     try:
-        logger.info("Removing '{}' folder tree...".format(folder))
+        logger.debug("Removing '{}' folder tree...".format(folder))
         shutil.rmtree(folder)
         return folder
     except Exception as e:
@@ -174,7 +174,7 @@ def extract_file_from_zip(file_to_extract_path: str, zip_file: str, output_dir: 
         if file_to_extract_path in zf.namelist():
             _, dst_file_name = os.path.split(file_to_extract_path)
             with open(os.path.join(output_dir, dst_file_name), "wb") as f:
-                logger.info(f"Extracting {file_to_extract_path} from {zip_file} to {f.name}")
+                logger.debug(f"Extracting {file_to_extract_path} from {zip_file} to {f.name}")
                 f.write(zf.read(file_to_extract_path))
                 return f.name
     return ''

--- a/modules/common/__init__.py
+++ b/modules/common/__init__.py
@@ -10,9 +10,6 @@ import binascii
 
 from datetime import datetime
 
-# WARNING - This file is for flagging the folder as a module for the python interpreter, it's usually left empty, or
-#  used for module-wide imports, initialization, but not as a code library. This code should be refactored out from here
-#  into their corresponding helper modules
 logger = logging.getLogger(__name__)
 
 

--- a/platform-input-support.py
+++ b/platform-input-support.py
@@ -18,7 +18,7 @@ def print_list_steps(keys_list):
     print(list_steps)
 
 
-# This procedure reads the config file and the args and runs the plugins requested.å
+# This procedure reads the config file and the args and runs the plugins requested.
 def main():
     cfg.setup_parser()
     args = cfg.get_args()

--- a/plugins/Disease.py
+++ b/plugins/Disease.py
@@ -115,8 +115,10 @@ class Disease(IPlugin):
         :param output: output folder for collected and pre-processed data
         :param cmd_conf: command line tools configuration
         """
+        self._logger.info("[STEP] BEGIN, Disease")
         riot = Riot(cmd_conf)
         self.get_ontology_EFO(conf, output, riot)
         self.get_ontology_mondo(conf, output, riot)
         self.get_ontology_hpo(conf, output, riot)
         self.get_hpo_phenotypes(conf, output)
+        self._logger.info("[STEP] END, Disease")

--- a/plugins/Drug.py
+++ b/plugins/Drug.py
@@ -33,6 +33,7 @@ class Drug(IPlugin):
         results = []
         elasticsearch_reader = ElasticsearchInstance(url)
         if elasticsearch_reader.is_reachable():
+            # TODO Easy point of improvement, parallelize indexes data collection by using one process per index
             for index in list(indices.values()):
                 index_name = index['name']
                 outfile = os.path.join(output_dir, "{}.jsonl".format(index_name))

--- a/plugins/Drug.py
+++ b/plugins/Drug.py
@@ -90,6 +90,7 @@ class Drug(IPlugin):
         :param output: output folder
         :param cmd_conf: UNUSED
         """
+        # TODO - Handle errors in the process and report back
         self._logger.info("Drug step")
         Downloads(output.prod_dir).exec(conf)
         self._logger.info("Drug download indices")

--- a/plugins/Drug.py
+++ b/plugins/Drug.py
@@ -91,7 +91,7 @@ class Drug(IPlugin):
         :param cmd_conf: UNUSED
         """
         # TODO - Handle errors in the process and report back
-        self._logger.info("Drug step")
+        self._logger.info("[STEP] BEGIN, Drug")
         Downloads(output.prod_dir).exec(conf)
-        self._logger.info("Drug download indices")
         self.download_indices(conf, output)
+        self._logger.info("[STEP] END, Drug")

--- a/plugins/Evidence.py
+++ b/plugins/Evidence.py
@@ -23,5 +23,6 @@ class Evidence(IPlugin):
         :param output: output folder information
         :param cmd_conf: UNUSED
         """
-        self._logger.info("Evidence step")
+        self._logger.info("[STEP] BEGIN, Evidence")
         Downloads(output.prod_dir).exec(conf)
+        self._logger.info("[STEP] END, Evidence")

--- a/plugins/Expression.py
+++ b/plugins/Expression.py
@@ -77,7 +77,8 @@ class Expression(IPlugin):
         :param output: output folder information
         :param cmd_conf: NOT USED
         """
-        self._logger.info("Expression step")
+        self._logger.info("[STEP] BEGIN, Expression")
         Downloads(output.prod_dir).exec(conf)
         self.get_tissue_map(output, conf.etl.tissue_translation_map)
         self.get_normal_tissues(output, conf.etl.normal_tissues)
+        self._logger.info("[STEP] END, Expression")

--- a/plugins/GO.py
+++ b/plugins/GO.py
@@ -23,5 +23,6 @@ class GO(IPlugin):
         :param output: data collection destination information object
         :param cmd_conf: NOT USED
         """
-        self._logger.info("GO step")
+        self._logger.info("[STEP] BEGIN, GO")
         Downloads(output.prod_dir).exec(conf)
+        self._logger.info("[STEP] END, GO")

--- a/plugins/Interactions.py
+++ b/plugins/Interactions.py
@@ -23,5 +23,6 @@ class Interactions(IPlugin):
         :param output: output information object on where the results of this step should be placed
         :param cmd_conf: NOT USED
         """
-        self._logger.info("Interactions step")
+        self._logger.info("[STEP] BEGIN, Interactions")
         Downloads(output.prod_dir).exec(conf)
+        self._logger.info("[STEP] END, Interactions")

--- a/plugins/Literature.py
+++ b/plugins/Literature.py
@@ -23,5 +23,6 @@ class Literature(IPlugin):
         :param output: output information object on where the results of this step should be placed
         :param cmd_conf: NOT USED
         """
-        self._logger.info("Literature step")
+        self._logger.info("[STEP] BEGIN, Literature")
         Downloads(output.prod_dir).exec(conf)
+        self._logger.info("[STEP] END, Literature")

--- a/plugins/MousePhenotypes.py
+++ b/plugins/MousePhenotypes.py
@@ -23,5 +23,6 @@ class MousePhenotypes(IPlugin):
         :param output: destination information for the results of this step
         :param cmd_conf: NOT USED
         """
-        self._logger.info("MousePhenotypes step")
+        self._logger.info("[STEP] BEGIN, mousephenotypes")
         Downloads(output.prod_dir).exec(conf)
+        self._logger.info("[STEP] END, mousephenotypes")

--- a/plugins/Openfda.py
+++ b/plugins/Openfda.py
@@ -89,6 +89,7 @@ class Openfda(IPlugin):
         :param output: output folder for collected OpenFDA data
         :param cmd_conf: UNUSED
         """
-        self._logger.info("Openfda step")
+        self._logger.info("[STEP] BEGIN, openfda")
         Downloads(output.prod_dir).exec(conf)
         self._download_openfda_faers(conf.etl.downloads, output)
+        self._logger.info("[STEP] END, openfda")

--- a/plugins/Openfda.py
+++ b/plugins/Openfda.py
@@ -1,6 +1,5 @@
 import os
 import json
-import tqdm
 import logging
 import multiprocessing as mp
 from yapsy.IPlugin import IPlugin
@@ -41,25 +40,23 @@ class Openfda(IPlugin):
         downloaded_files = dict()
         # Body
         if repo_metadata:
-            self._logger.info("OpenFDA FAERs metadata received")
+            self._logger.debug("OpenFDA FAERs metadata received")
             fda_output = create_folder(os.path.join(output.prod_dir, "fda-inputs"))
             fda = OpenfdaHelper(fda_output)
             # Parallel data gathering
-            self._logger.info("Prepare download pool of {} processes".format(mp.cpu_count()))
+            self._logger.debug("Download processes pool -- {}".format(mp.cpu_count()))
             download_pool_nprocesses = mp.cpu_count() * 2
             download_pool_chunksize = int(
                 len(repo_metadata['results']['drug']['event']['partitions']) / download_pool_nprocesses
             )
             with mp.Pool() as download_pool:
-                self._logger.info(mp.current_process())
+                # self._logger.info(mp.current_process())
                 try:
-                    for _ in tqdm.tqdm(download_pool.map(fda._do_download_openfda_event_file,
-                                                         repo_metadata['results']['drug']['event']['partitions'],
-                                                         chunksize=download_pool_chunksize),
-                                       total=len(repo_metadata['results']['drug']['event']['partitions'])):
-                        self._logger.info('\rdone {0:%}'.format(_ / len(repo_metadata['results']['drug']['event']['partitions'])))
+                    download_pool.map(fda._do_download_openfda_event_file,
+                                      repo_metadata['results']['drug']['event']['partitions'],
+                                      chunksize=download_pool_chunksize)
                 except Exception as e:
-                    self._logger.info("Something went wrong: " + str(e))
+                    self._logger.error("Something went wrong: " + str(e))
         return downloaded_files
 
     def _download_openfda_faers(self, resource, output):

--- a/plugins/Otar.py
+++ b/plugins/Otar.py
@@ -17,13 +17,13 @@ class Otar(IPlugin):
         self.logger = logging.getLogger(__name__)
 
     def process(self, conf, output, cmd_conf=None):
-        self.logger.info("OTAR Projects data collection - START -")
+        self._logger.info("[STEP] BEGIN, otar")
         gcp_credentials = conf.google_credential_key
         dst_folder = os.path.join(output.prod_dir, conf.gs_output_dir)
         self.logger.debug("Prepare destination folder at '{}'".format(dst_folder))
         create_folder(dst_folder)
         if gcp_credentials is None:
-            self.logger.warning("NO GCP credentials have been provided")
+            self.logger.error("NO GCP credentials have been provided")
         # TODO - Parallelize this
         for sheet in conf.sheets:
             path_dst = os.path.join(dst_folder, sheet.output_filename)
@@ -33,3 +33,4 @@ class Otar(IPlugin):
                                               sheet.output_format,
                                               gcp_credentials)
             handler.download()
+        self._logger.info("[STEP] END, otar")

--- a/plugins/Reactome.py
+++ b/plugins/Reactome.py
@@ -23,5 +23,6 @@ class Reactome(IPlugin):
         :param outputs: output location information object for step results
         :param cmd_conf: NOT USED
         """
-        self._logger.info("Reactome step")
+        self._logger.info("[STEP] BEGIN, reactome")
         Downloads(outputs.prod_dir).exec(conf)
+        self._logger.info("[STEP] END, reactome")

--- a/plugins/SO.py
+++ b/plugins/SO.py
@@ -27,8 +27,10 @@ class SO(IPlugin):
         :param output: output information object for the results of this pipeline step
         :param cmd_conf: command line tools configuration object
         """
+        self._logger.info("[STEP] BEGIN, so")
         riot = Riot(cmd_conf)
         filename_input = Downloads.download_staging_http(output.staging_dir, conf.etl)
         file_ouput_path = os.path.join(output.prod_dir, conf.etl.path)
         create_folder(file_ouput_path)
         riot.convert_owl_to_jsonld(filename_input, file_ouput_path, conf.etl.owl_jq)
+        self._logger.info("[STEP] END, so")

--- a/plugins/Target.py
+++ b/plugins/Target.py
@@ -70,7 +70,6 @@ class Target(IPlugin):
         :param project_score_entry: project scoring data download information
         :param output: output configuration object for download
         """
-        logger.info("Downloading project scores target files")
         # we only want one file from a zipped archive
         file_of_interest = 'EssentialityMatrices/04_binaryDepScores.tsv'
         file_input = Downloads.download_staging_http(output.staging_dir, project_score_entry)
@@ -86,9 +85,10 @@ class Target(IPlugin):
         :param output: output configuration object for step results
         :param cmd_conf: command line tools configuration object
         """
-        self._logger.info("Target step")
+        self._logger.info("[STEP] BEGIN, target")
         Downloads(output.prod_dir).exec(conf)
         self.get_project_scores(conf.etl.project_scores, output)
         self.extract_ensembl(conf.etl.ensembl, output, cmd_conf)
         self.get_subcellular_location(conf.etl.subcellular_location, output)
         self.get_gnomad(conf.etl.gnomad, output)
+        self._logger.info("[STEP] END, target")

--- a/plugins/helpers/EFO.py
+++ b/plugins/helpers/EFO.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 The current implementation is based on the conversion from owl format to json lines format using Apache RIOT
 The structure disease_obsolete stores the obsolete terms and it is used to retrieve the relationship between valid
     term and obsolete terms.
-The locationIds are generated retriving the structure parent/child and recursevely retrieve the proper info
+The locationIds are generated retrieving the structure parent/child and recursively retrieve the proper info
 """
 
 

--- a/plugins/helpers/EFO.py
+++ b/plugins/helpers/EFO.py
@@ -209,7 +209,7 @@ class EFO(object):
         elif (simple_id.group() in 'Orphanet_'):
             return "http://www.orpha.net/ORDO/"
         else:
-            logger.error("Match fail for {}".format(id))
+            logger.warning("Match fail for {}".format(id))
             return "http://purl.obolibrary.org/obo/"
 
     def extract_id_from_uri(self, uri):

--- a/plugins/helpers/HPO.py
+++ b/plugins/helpers/HPO.py
@@ -48,7 +48,7 @@ class HPO(object):
         elif '@id' in hp:
             return re.sub(r'^.*?:', '', hp['@id']).replace(":", "_")
         else:
-            print("skip this id:" + hp)
+            logger.debug("skip this id:" + hp)
 
     def is_not_obsolete(self, id, hpo):
         """

--- a/plugins/helpers/MONDO.py
+++ b/plugins/helpers/MONDO.py
@@ -49,7 +49,9 @@ class MONDO(object):
             return re.sub(r'^.*?:', '', mondo['@id'])
         else:
             # NOTE WHAAAAT? hahaha!
-            print("orrore")
+            logger.warning(
+                "WTF just happened here? - neither 'id' nor '@id' has been found in this MONDO item: '{}'".format(
+                    mondo))
 
     def set_dbXRefs(self, id, mondo):
         """

--- a/plugins/helpers/OpenfdaHelper.py
+++ b/plugins/helpers/OpenfdaHelper.py
@@ -14,14 +14,20 @@ class OpenfdaHelper(object):
     OpenFDA data download Helper with re-entrant download event file method for multithreading safety.
     """
 
-    def __init__(self, output_dir):
+    def __init__(self, output_dir, logger=None):
         """
         Constructor
 
         :param output_dir: destination folder for the downloaded event file
         """
         self.output = output_dir
-        self._logger = logging.getLogger(__name__)
+        self._logger = logger
+
+    @property
+    def logger(self):
+        if self._logger is None:
+            self._logger = logger
+        return self._logger
 
     def _do_download_openfda_event_file(self, download_entry):
         """
@@ -29,16 +35,16 @@ class OpenfdaHelper(object):
 
         :param download_entry: download information object
         """
-        self._logger.debug(download_entry)
+        self.logger.debug(download_entry)
         download_url = download_entry['file']
         download_description = download_entry['display_name']
         download_src_filename = os.path.basename(urlparse(download_url).path)
         download_dest_filename = "{}.zip".format(uuid.uuid4())
         download_dest_path = os.path.join(self.output, download_dest_filename)
         download_resource_key = "openfda-event-{}".format(download_dest_filename)
-        self._logger.info("Download OpenFDA FAERs '{}', from '{}', destination file name '{}'".format(download_description,
+        self.logger.info("Download OpenFDA FAERs '{}', from '{}' --> '{}'".format(download_description,
                                                                                                 download_url,
-                                                                                                download_src_filename))
+                                                                                                download_dest_filename))
         download_resource = type('download_resource', (object,), {
             'uri': download_url,
             'unzip_file': True,
@@ -47,24 +53,23 @@ class OpenfdaHelper(object):
             'accept': 'application/zip'
         })
         # Download the file
-        DownloadResource(self.output) \
-            .execute_download(download_resource, 7)
+        DownloadResource(self.output).execute_download(download_resource, 7)
         with zipfile.ZipFile(download_dest_path, 'r') as zipf:
             for event_file in zipf.filelist:
                 unzip_filename = event_file.filename
                 unzip_dest_filename = "{}.jsonl".format(uuid.uuid4())
                 unzip_dest_path = os.path.join(self.output, unzip_dest_filename)
-                self._logger.debug("Inflating event file '{}', CRC '{}'".format(unzip_filename, event_file.CRC))
+                self.logger.debug("Inflating event file '{}', CRC '{}'".format(unzip_filename, event_file.CRC))
                 with zipf.open(unzip_filename, 'r') as compressedf:
                     with open(unzip_dest_path, 'w') as inflatedf:
-                        self._logger.debug("Extracting event file results")
+                        self.logger.debug("Extracting event file results")
                         event_data = json.load(compressedf)
                         if event_data['results']:
                             for result in event_data['results']:
                                 inflatedf.write("{}\n".format(json.dumps(result)))
                         else:
-                            self._logger.warning(
+                            self.logger.warning(
                                 "NO EVENT DATA RESULTS for event file '{}', source URL '{}', description '{}'".format(
                                     unzip_filename, download_url, download_description))
-        self._logger.warning("Removing processed ZIP file '{}'".format(download_dest_path))
+        self.logger.debug("Removing processed ZIP file '{}'".format(download_dest_path))
         os.remove(download_dest_path)

--- a/plugins/helpers/OpenfdaHelper.py
+++ b/plugins/helpers/OpenfdaHelper.py
@@ -53,10 +53,10 @@ class OpenfdaHelper(object):
                 unzip_filename = event_file.filename
                 unzip_dest_filename = "{}.jsonl".format(uuid.uuid4())
                 unzip_dest_path = os.path.join(self.output, unzip_dest_filename)
-                logger.info("Inflating event file '{}', CRC '{}'".format(unzip_filename, event_file.CRC))
+                logger.debug("Inflating event file '{}', CRC '{}'".format(unzip_filename, event_file.CRC))
                 with zipf.open(unzip_filename, 'r') as compressedf:
                     with open(unzip_dest_path, 'w') as inflatedf:
-                        logger.info("Extracting event file results")
+                        logger.debug("Extracting event file results")
                         event_data = json.load(compressedf)
                         if event_data['results']:
                             for result in event_data['results']:

--- a/plugins/helpers/OpenfdaHelper.py
+++ b/plugins/helpers/OpenfdaHelper.py
@@ -21,6 +21,7 @@ class OpenfdaHelper(object):
         :param output_dir: destination folder for the downloaded event file
         """
         self.output = output_dir
+        self._logger = logging.getLogger(__name__)
 
     def _do_download_openfda_event_file(self, download_entry):
         """
@@ -28,14 +29,14 @@ class OpenfdaHelper(object):
 
         :param download_entry: download information object
         """
-        logger.info(download_entry)
+        self._logger.debug(download_entry)
         download_url = download_entry['file']
         download_description = download_entry['display_name']
         download_src_filename = os.path.basename(urlparse(download_url).path)
         download_dest_filename = "{}.zip".format(uuid.uuid4())
         download_dest_path = os.path.join(self.output, download_dest_filename)
         download_resource_key = "openfda-event-{}".format(download_dest_filename)
-        logger.info("Download OpenFDA FAERs '{}', from '{}', destination file name '{}'".format(download_description,
+        self._logger.info("Download OpenFDA FAERs '{}', from '{}', destination file name '{}'".format(download_description,
                                                                                                 download_url,
                                                                                                 download_src_filename))
         download_resource = type('download_resource', (object,), {
@@ -53,21 +54,17 @@ class OpenfdaHelper(object):
                 unzip_filename = event_file.filename
                 unzip_dest_filename = "{}.jsonl".format(uuid.uuid4())
                 unzip_dest_path = os.path.join(self.output, unzip_dest_filename)
-                logger.debug("Inflating event file '{}', CRC '{}'".format(unzip_filename, event_file.CRC))
+                self._logger.debug("Inflating event file '{}', CRC '{}'".format(unzip_filename, event_file.CRC))
                 with zipf.open(unzip_filename, 'r') as compressedf:
                     with open(unzip_dest_path, 'w') as inflatedf:
-                        logger.debug("Extracting event file results")
+                        self._logger.debug("Extracting event file results")
                         event_data = json.load(compressedf)
                         if event_data['results']:
                             for result in event_data['results']:
                                 inflatedf.write("{}\n".format(json.dumps(result)))
                         else:
-                            logger.warning(
+                            self._logger.warning(
                                 "NO EVENT DATA RESULTS for event file '{}', source URL '{}', description '{}'".format(
                                     unzip_filename, download_url, download_description))
-        logger.warning("Removing processed ZIP file '{}'".format(download_dest_path))
+        self._logger.warning("Removing processed ZIP file '{}'".format(download_dest_path))
         os.remove(download_dest_path)
-
-
-if __name__ == '__main__':
-    pass

--- a/resources/logging.ini
+++ b/resources/logging.ini
@@ -30,7 +30,7 @@ args=(sys.stdout,)
 
 [handler_file]
 class=FileHandler
-formatter=simpleFormatter
+formatter=complexFormatter
 #log to this filename, and append after any existing content
 args=('log/output.log','a')
 


### PR DESCRIPTION
This PR solves opentargets/issues#2718 by revisiting logging in PIS and taking the following actions:
- Remove excessive logging from libraries.
- Review of log messages and levels.
- Include time stamp for log messages in the log file handler.