### PR TITLE
Remove EFO version information from PIS data collection

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -14,7 +14,7 @@ disease:
     path: ontology-inputs
    efo:
     uri: https://github.com/EBISPOT/efo/releases/download/v3.45.0/efo_otar_slim.owl
-    output_filename: ontology-efo-v3.45.0.jsonl
+    output_filename: ontology-efo.jsonl
     path: ontology-inputs
     owl_jq: '.["@graph"][] | select (.["@type"] == ("Class","Restriction") and ."@id" != null)|.subClassOf=([.subClassOf]|flatten|del(.[]|nulls))|.hasExactSynonym=([.hasExactSynonym]|flatten|del(.[]|nulls))|.hasDbXref=([.hasDbXref]|flatten|del(.[]|nulls))|.inSubset=([.inSubset]|flatten|del(.[]|nulls))|.hasAlternativeId=([.hasAlternativeId]|flatten|del(.[]|nulls))|@json'
     diseases_static_file: diseases_efo.jsonl


### PR DESCRIPTION
This PR removes the EFO version information from the file name in the _ontology-inputs_ collected by PIS.

It solves opentargets/issues#2725