### PR TITLE
Homologues refactoring and separation of concerns

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -332,12 +332,6 @@ target:
   - uri: https://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_40/gencode.v40.annotation.gff3.gz
     output_filename: gencode.gff3.gz
     path: target-inputs/gencode
-  - uri: https://ftp.ensembl.org/pub/release-108/tsv/ensembl-compara/homologies/homo_sapiens/Compara.108.protein_default.homologies.tsv.gz
-    output_filename: cpd.tsv.gz
-    path: target-inputs/homologue
-  - uri: https://ftp.ensembl.org/pub/release-108/tsv/ensembl-compara/homologies/homo_sapiens/Compara.108.ncrna_default.homologies.tsv.gz
-    output_filename: crna.tsv.gz
-    path: target-inputs/homologue
   - uri: https://ftp.ebi.ac.uk/pub/databases/RNAcentral/current_release/id_mapping/database_mappings/ensembl.tsv
     output_filename: ensembl.tsv
     path: target-inputs/go

--- a/config.yaml
+++ b/config.yaml
@@ -214,7 +214,7 @@ go:
     path: gene-ontology-inputs
 homologues:
   uri: https://ftp.ensembl.org/pub/release-{release}/json/
-  path_protein_mapping: 'protein_mapping'
+  path_gene_dictionary: 'gene_dictionary'
   uri_homologues: https://ftp.ensembl.org/pub/release-{release}/tsv/ensembl-compara/homologies
   path_homologues: 'homologies'
   types_homologues:

--- a/plugins/Homologues.py
+++ b/plugins/Homologues.py
@@ -41,7 +41,7 @@ class Homologues(IPlugin):
         self.step_name = "Homologues"
 
     @staticmethod
-    def download_protein_mapping_for_species(uri, staging, download, species: str) -> ManifestResource:
+    def download_gene_dictionary_for_species(uri, staging, download, species: str) -> ManifestResource:
         """
         Download protein homology for species and suffix if file does not already exist.
 
@@ -106,16 +106,16 @@ class Homologues(IPlugin):
             raise
         return output_file
 
-    def download_protein_mapping_data(self, conf, output, cmd_conf) -> List[ManifestResource]:
+    def download_gene_dictionary_data(self, conf, output, cmd_conf) -> List[ManifestResource]:
         """
-        Download the protein mapping data for the species of interest, as defined in the configuration file.
+        Download the gene dictionary data for the species of interest, as defined in the configuration file.
 
         :param conf: configuration object
         :param output: information on where the output result should be place
         :param cmd_conf: configuration for the command line
         """
-        path_output = os.path.join(output.prod_dir, conf.path, str(conf.path_protein_mapping))
-        path_staging = os.path.join(output.staging_dir, conf.path, str(conf.path_protein_mapping))
+        path_output = os.path.join(output.prod_dir, conf.path, str(conf.path_gene_dictionary))
+        path_staging = os.path.join(output.staging_dir, conf.path, str(conf.path_gene_dictionary))
         create_folder(path_staging)
         create_folder(path_output)
         download_service = DownloadResource(path_staging)
@@ -125,7 +125,7 @@ class Homologues(IPlugin):
         for species in conf.resources:
             # Download the protein files for each species of interest
             self._logger.debug(f'Downloading protein mapping files for {species}')
-            download_manifest = self.download_protein_mapping_for_species(ensembl_base_uri, output.staging_dir,
+            download_manifest = self.download_gene_dictionary_for_species(ensembl_base_uri, output.staging_dir,
                                                                           download_service,
                                                                           species)
             if download_manifest.status_completion == ManifestStatus.COMPLETED:
@@ -188,9 +188,9 @@ class Homologues(IPlugin):
         self._logger.info("[STEP] BEGIN, Homologues")
         # TODO - Should I halt the step as soon as I face the first problem?
         manifest_step = get_manifest_service().get_step(self.step_name)
-        # Download protein mapping data
+        # Download gene dictionary data
         manifest_step.resources.extend(
-            self.download_protein_mapping_data(conf, output, cmd_conf))
+            self.download_gene_dictionary_data(conf, output, cmd_conf))
         # Download homology data
         manifest_step.resources.extend(
             self.download_homology_data(conf, output))

--- a/plugins/Homologues.py
+++ b/plugins/Homologues.py
@@ -43,7 +43,7 @@ class Homologues(IPlugin):
     @staticmethod
     def download_gene_dictionary_for_species(uri, staging, download, species: str) -> ManifestResource:
         """
-        Download protein homology for species and suffix if file does not already exist.
+        Download gene dictionary for species and suffix if file does not already exist.
 
         Most entries do not require suffix to be provided, but some such as sus_scrofa_usmarc have no standard ftp
         entries requiring a custom suffix.
@@ -124,7 +124,7 @@ class Homologues(IPlugin):
         mapping_data_manifests = []
         for species in conf.resources:
             # Download the protein files for each species of interest
-            self._logger.debug(f'Downloading protein mapping files for {species}')
+            self._logger.debug(f'Downloading gene dictionary files for {species}')
             download_manifest = self.download_gene_dictionary_for_species(ensembl_base_uri, output.staging_dir,
                                                                           download_service,
                                                                           species)
@@ -135,18 +135,18 @@ class Homologues(IPlugin):
                         self.extract_fields_from_json(
                             download_manifest.path_destination, conf, path_output, jq_cmd)
                 except Exception as e:
-                    download_manifest.msg_completion = f"COULD NOT extract fields from Protein dataset at " \
+                    download_manifest.msg_completion = f"COULD NOT extract fields from gene dictionary dataset at " \
                                                        f"'{download_manifest.path_destination}'" \
                                                        f" using JQ command '{jq_cmd}', due to error: {str(e)}"
                     self._logger.error(download_manifest.msg_completion)
                 else:
                     self._logger.debug(
-                        f"Protein mapping data for '{species}' download manifest destination path"
+                        f"Gene dictionary data for '{species}' download manifest destination path"
                         f" set to '{download_manifest.path_destination}',"
                         f" as final recipient for the sub-dataset"
                     )
                     download_manifest.msg_completion = \
-                        f"Homologue '{species}' data, JQ filtered with '{conf.jq}'"
+                        f"Gene dictionary data for '{species}', JQ filtered with '{conf.jq}'"
                     download_manifest.status_completion = ManifestStatus.COMPLETED
             mapping_data_manifests.append(download_manifest)
         return mapping_data_manifests


### PR DESCRIPTION
This PR performs a refactoring in the homology data collection process, removing the Ensembl Compara files related to _Home Spiens_ from _target_ step, and handing over to _homologues_ step the collection of:
- _Gene Dictionaries_
- And _Homology_ data

The new _homologue_ folder within _target-inputs_ now looks like:
```bash
drwxr-x---@ 16 mbernal  staff   512B 23 mar 15:07 gene_dictionary
drwxr-x---@ 30 mbernal  staff   960B 23 mar 15:19 homologies
-rw-r-----@  1 mbernal  staff    49K 23 mar 12:19 species_EnsemblVertebrates.txt

❯ tree
.
├── gene_dictionary
│   ├── caenorhabditis_elegans.tsv
│   ├── canis_lupus_familiaris.tsv
│   ├── cavia_porcellus.tsv
│   ├── danio_rerio.tsv
│   ├── drosophila_melanogaster.tsv
│   ├── homo_sapiens.tsv
│   ├── macaca_mulatta.tsv
│   ├── mus_musculus.tsv
│   ├── oryctolagus_cuniculus.tsv
│   ├── pan_troglodytes.tsv
│   ├── rattus_norvegicus.tsv
│   ├── sus_scrofa.tsv
│   ├── sus_scrofa_usmarc.tsv
│   └── xenopus_tropicalis.tsv
├── homologies
│   ├── ncrna-caenorhabditis_elegans.tsv.gz
│   ├── ncrna-canis_lupus_familiaris.tsv.gz
│   ├── ncrna-cavia_porcellus.tsv.gz
│   ├── ncrna-danio_rerio.tsv.gz
│   ├── ncrna-drosophila_melanogaster.tsv.gz
│   ├── ncrna-homo_sapiens.tsv.gz
│   ├── ncrna-macaca_mulatta.tsv.gz
│   ├── ncrna-mus_musculus.tsv.gz
│   ├── ncrna-oryctolagus_cuniculus.tsv.gz
│   ├── ncrna-pan_troglodytes.tsv.gz
│   ├── ncrna-rattus_norvegicus.tsv.gz
│   ├── ncrna-sus_scrofa.tsv.gz
│   ├── ncrna-sus_scrofa_usmarc.tsv.gz
│   ├── ncrna-xenopus_tropicalis.tsv.gz
│   ├── protein-caenorhabditis_elegans.tsv.gz
│   ├── protein-canis_lupus_familiaris.tsv.gz
│   ├── protein-cavia_porcellus.tsv.gz
│   ├── protein-danio_rerio.tsv.gz
│   ├── protein-drosophila_melanogaster.tsv.gz
│   ├── protein-homo_sapiens.tsv.gz
│   ├── protein-macaca_mulatta.tsv.gz
│   ├── protein-mus_musculus.tsv.gz
│   ├── protein-oryctolagus_cuniculus.tsv.gz
│   ├── protein-pan_troglodytes.tsv.gz
│   ├── protein-rattus_norvegicus.tsv.gz
│   ├── protein-sus_scrofa.tsv.gz
│   ├── protein-sus_scrofa_usmarc.tsv.gz
│   └── protein-xenopus_tropicalis.tsv.gz
└── species_EnsemblVertebrates.txt

3 directories, 43 files
```