### PR TITLE
2915 sus_scrofa_usmarc

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -235,7 +235,6 @@ homologues:
       - 'pan_troglodytes'
       - 'rattus_norvegicus'
       - 'sus_scrofa'
-      - 'sus_scrofa_usmarc'
       - 'xenopus_tropicalis'
       - 'homo_sapiens'
 interactions:


### PR DESCRIPTION
Based on issue [2915](https://github.com/opentargets/issues/issues/2915) we should remove sus_scrofa_usmarc from the species of interest list.