### PR TITLE
Update python version in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
   - conda update --yes conda
 install:
   # Set up a conda environment with the right Python version.
-  - conda env create --force -f environment.yaml --python=$TRAVIS_PYTHON_VERSION
+  - conda env create --force -f environment.yaml
   - source activate otpis
 script:
    - python -m pytest --cov=modules --cov-report term tests/ --fulltrace

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "3.8.8"
+  - "3.8"
 services:
   - docker
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
   - conda update --yes conda
 install:
   # Set up a conda environment with the right Python version.
-  - conda env create --force -f environment.yaml python=$TRAVIS_PYTHON_VERSION
+  - conda env create --force -f environment.yaml --python=$TRAVIS_PYTHON_VERSION
   - source activate otpis
 script:
    - python -m pytest --cov=modules --cov-report term tests/ --fulltrace

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "3.8"
+  - "3.8.8"
 services:
   - docker
 env:

--- a/environment.yaml
+++ b/environment.yaml
@@ -12,7 +12,7 @@ dependencies:
  - gspread
  - mock
  - pip
- - python=3.8.8
+ - python=3.8
  - pytest
  - pytest-cov
  - pyyaml

--- a/environment.yaml
+++ b/environment.yaml
@@ -12,7 +12,7 @@ dependencies:
  - gspread
  - mock
  - pip
- - python=3.8
+ - python=3.8.8
  - pytest
  - pytest-cov
  - pyyaml


### PR DESCRIPTION
The inconsistency between the Python version specified in .travis.yml file (3.8) and the environment.yaml file (3.8.8) can cause compatibility issues and potentially lead to the SpecNotFound error.