### PR TITLE
Adding gene essentiality annotation to the target step

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -311,6 +311,9 @@ target:
     output_filename: uniprot-ssl.tsv.gz
     path: target-inputs/uniprot
   gs_downloads_latest:
+  - bucket: otar000-evidence_input/Essentiality/json
+    output_filename: essentiality.json.gz
+    path: target-inputs/gene-essentiality
   - bucket: otar001-core/subcellularLocations
     output_filename: subcellular_locations_ssl.tsv
     path: target-inputs/hpa


### PR DESCRIPTION
For the 23.06. Platfrom release a new target annotation, Gene Essentiality is planned (Issue [#2917](https://github.com/opentargets/issues/issues/2917)). The dataset is pulled from:
` gs://otar000-evidence_input/Essentiality/json/`

The dataset is expected to re-generated for each release and named accordingly, therefore the step was added to the `gs_downloads_latest` section.

