### PR TITLE
Update STRING interaction dataset

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -241,6 +241,10 @@ homologues:
       - 'xenopus_tropicalis'
       - 'homo_sapiens'
 interactions:
+  gs_downloads_latest:
+  - bucket: otar001-core/stringInteractions
+    output_filename: string-interactions.txt.gz
+    path: interactions-inputs
   ftp_downloads:
   - uri: https://ftp.ebi.ac.uk/pub/databases/RNAcentral/current_release/id_mapping/database_mappings/ensembl.tsv
     output_filename: rna_central_ensembl.tsv
@@ -251,13 +255,7 @@ interactions:
   - uri : https://ftp.ebi.ac.uk/pub/databases/intact/various/ot_graphdb/current/data/interactor_pair_interactions.json
     output_filename: intact-interactors.json
     path: interactions-inputs
-  - uri : https://ftp.ebi.ac.uk/pub/databases/opentargets/platform/22.11/input/interactions-inputs/9606.protein.links.full_w_homology.v11.5.txt.gz
-    output_filename: 9606_protein_links.txt.gz
-    path: interactions-inputs
   http_downloads:
-  - uri: https://stringdb-static.org/download/protein.links.detailed.v11.5/9606.protein.links.detailed.v11.5.txt.gz
-    output_filename: string-interactions.json.gz
-    path: interactions-inputs
   - uri: https://ftp.ensembl.org/pub/release-109/gtf/homo_sapiens/Homo_sapiens.GRCh38.109.chr.gtf.gz
     output_filename: Homo_sapiens.GRCh38.chr.gtf.gz
     path: interactions-inputs


### PR DESCRIPTION
- STRING derived interaction is bumped to the newest release (v.12.0). 
- Output file is renamed to make it more intuitive. (Dependency: the ETL code also needs to be updated. )
- Also sourced from GS bucket. Files are dated.
- `string-interactions.json.gz` is removed as it is not picked up by the ETL

More info: [#3026](https://github.com/opentargets/issues/issues/3026)