### PR TITLE
2798 target step subproc refactoring

### DIFF
--- a/plugins/Target.py
+++ b/plugins/Target.py
@@ -110,7 +110,7 @@ class Target(IPlugin):
         if download_manifest.status_completion == ManifestStatus.COMPLETED:
             output_dir = os.path.join(output.prod_dir, ensembl.path)
             output_file = os.path.join(create_folder(output_dir), ensembl.output_filename)
-            cmd = f"{jq_cmd} -c {ensembl.jq} {download_manifest.path_destination} > {output_file}"
+            cmd = f"{jq_cmd} -c '{ensembl.jq}' {download_manifest.path_destination} > {output_file}"
             try:
                 subproc(cmd)
             except CustomSubProcException as e:


### PR DESCRIPTION
Resolves opentargets/issues#2798. 
- Refactored the subprocess call in the "target" step use the custom subprocess function from Utils.
- Tested on VM (32GB):
  - fail case (malformed jq filter): manifest has useful log message:
    `"msg_completion": "FAILED to extract ensembl data from '/srv/output/staging/homo_sapiens.json' into '/srv/output/prod/target-inputs/ensembl/homo_sapiens.jsonl' using JQ filter '.genes[] | {id: .id, biotype: .biotype, description: .description, end: .end, start: .start, strand: .strand, chromosome: .seq_region_name, approvedSymbol: .name, transcripts: .transcripts, signalP: .SignalP, uniprot_trembl: .\"Uniprot/SPTREMBL\", uniprot_swissprot: .\"Uniprot/SWISSPROT\"}' due to 'FAILED to run command '/usr/bin/jq -c .genes[] | {id: .id, biotype: .biotype, description: .description, end: .end, start: .start, strand: .strand, chromosome: .seq_region_name, approvedSymbol: .name, transcripts: .transcripts, signalP: .SignalP, uniprot_trembl: .\"Uniprot/SPTREMBL\", uniprot_swissprot: .\"Uniprot/SWISSPROT\"} /srv/output/staging/homo_sapiens.json > /srv/output/prod/target-inputs/ensembl/homo_sapiens.jsonl', with return code '127', error: 'Command '/usr/bin/jq -c .genes[] | {id: .id, biotype: .biotype, description: .description, end: .end, start: .start, strand: .strand, chromosome: .seq_region_name, approvedSymbol: .name, transcripts: .transcripts, signalP: .SignalP, uniprot_trembl: .\"Uniprot/SPTREMBL\", uniprot_swissprot: .\"Uniprot/SWISSPROT\"} /srv/output/staging/homo_sapiens.json > /srv/output/prod/target-inputs/ensembl/homo_sapiens.jsonl' returned non-zero exit status 127.''"`
  - success case: works as expected/as before
