### PR TITLE
Update path for EVA evidence

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -146,7 +146,7 @@ evidence:
     output_filename: uniprot.json.gz
     output_spark_dir: uniprot
     path: evidence-files
-  - bucket: otar012-eva
+  - bucket: otar012-eva/disease-target-evidence
     output_filename: eva.json.gz
     output_spark_dir: eva
     path: evidence-files


### PR DESCRIPTION
Starting with the 23.12 release, EVA is going to submit two types of files: regular target-disease evidence; and the new pharmacogenomics dataset.

Accordingly, they changed the way files are organised in their bucket. It now looks like this:
* `gs://otar012-eva/`
  + `disease-target-evidence/`
    - `cttv012-2023-10-16.json.gz`
  + `pharmacogenomics/`
    - `cttv012-2023-10-12_pgkb.json.gz`

I've updated the path so that the target-disease evidence can be ingested without problems.

>**Warning**
>The update does not include anything related to the new pharmacogenomics dataset, as I'm not sure where best to put it into the config file. This will need to be addressed separately, probably as part of https://github.com/opentargets/issues/issues/3098.