### PR TITLE
Add nogcp makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ new_session: # Initialise the running context and start a new session
 		./${PATH_SCRIPTS}/init_context.sh' > ${PATH_PIS_SESSION_CONTEXT}
 
 .PHONY: switch_session
-switch_session: # Switch to another existing session e.g. "make switch_session session='abcdef1234'" (see folder 'sessions') 
+switch_session: # Switch to another existing session e.g. "make switch_session session='abcdef1234'" (see folder 'sessions')
 	@echo "[PIS] Switching to session: '${session}'"
 	@echo "${session}" > .sessionid
 
@@ -71,6 +71,18 @@ launch_local: gcp_credentials new_session config_init # Launch PIS locally
 	@echo "[PIS] Uploading config/context to GCS: ${OTOPS_PATH_GCS_PIS_SESSION_CONFIGS}/${current_session_id}"
 	@gsutil -m rsync -r ${PATH_PIS_SESSION} ${OTOPS_PATH_GCS_PIS_SESSION_CONFIGS}/${current_session_id}/
 	@echo "[PIS] Logs will be uploaded to GCS when pipeline has completed: ${OTOPS_PATH_GCS_PIS_SESSION_LOGS}${current_session_id}"
+
+.PHONY: launch_local_nogcp
+launch_local_nogcp: gcp_credentials new_session config_init # Launch PIS locally without uploading to GCS
+	@echo "[PIS] Session ID: ${current_session_id}"
+	@echo "[PIS] Launching PIS locally"
+	@echo "Loading context: ${PATH_PIS_SESSION_CONTEXT}"
+	$(eval include ${PIS_ACTIVE_PROFILE})
+	@echo "[PIS] Preparing dirs"
+	@mkdir -p ${OTOPS_PATH_PIS_OUTPUT_DIR}
+	@mkdir -p ${OTOPS_PATH_PIS_LOGS_DIR}
+	@echo "[PIS] Docker run with args: '${OTOPS_PIS_RUN_ARGS}'"
+	@bash ./${PATH_SCRIPTS}/run.sh --nogcp
 
 .PHONY: launch_remote
 launch_remote: gcp_credentials new_session config_init # Launch PIS remotely
@@ -118,4 +130,3 @@ clean_all_infrastructure: ## Clean all the infrastructures used for run PIS remo
 			terraform workspace delete $$ws ; \
 		fi \
 	done
-

--- a/launcher/scripts/pipeline/run.sh
+++ b/launcher/scripts/pipeline/run.sh
@@ -1,12 +1,29 @@
 #!/bin/bash
 
-config=$(realpath ${OTOPS_PATH_PIS_CONFIG})
-output=$(realpath ${OTOPS_PATH_PIS_OUTPUT_DIR})
-logs=$(realpath ${OTOPS_PATH_PIS_LOGS_DIR})
-creds=$(realpath ${OTOPS_PATH_GCS_CREDENTIALS_FILE})
+config=$(realpath "${OTOPS_PATH_PIS_CONFIG}")
+output=$(realpath "${OTOPS_PATH_PIS_OUTPUT_DIR}")
+logs=$(realpath "${OTOPS_PATH_PIS_LOGS_DIR}")
+creds=$(realpath "${OTOPS_PATH_GCS_CREDENTIALS_FILE}")
 #Removing outermost quotes
 pis_args="${OTOPS_PIS_RUN_ARGS#\"}"
 pis_args="${pis_args%\"}"
+
+gb_arg_line=
+
+params=$(getopt -o n --long nogcp -- "$@")
+eval set -- "$params"
+unset params
+
+case $1 in
+  -n|--nogcp)
+    gb_arg_line=""
+    ;;
+  --)
+    gb_arg_line="-gb ${OTOPS_PATH_GCS_PIS_OUTPUT}"
+    upload_logs=true
+    ;;
+esac
+
 
 run_cmd="docker run \
          -v ${output}:/srv/output \
@@ -17,9 +34,11 @@ run_cmd="docker run \
          -o /srv/output \
          --log-level=DEBUG \
          -gkey /srv/credentials/open-targets-gac.json \
-         -gb ${OTOPS_PATH_GCS_PIS_OUTPUT} \
+         $gb_arg_line \
          $pis_args"
 
 $run_cmd
 
-gsutil -m rsync -r ${logs}/ ${OTOPS_PATH_GCS_PIS_SESSION_LOGS}
+if [ -n "$upload_logs" ]; then
+  gsutil -m rsync -r "${logs}"/ "${OTOPS_PATH_GCS_PIS_SESSION_LOGS}"
+fi


### PR DESCRIPTION
This PR adds a new Makefile target (`launch_local_nogcp`) that runs PIS without performing any uploads to GCP buckets.