### PR TITLE
chore: update config.yaml

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -276,7 +276,7 @@ mousephenotypes:
     path: mouse-phenotypes-inputs
 pharmacogenomics:
   gs_downloads_latest:
-  - bucket: otar012-eva/pharmacogenomics
+  - bucket: otar001-core/Pharmacogenetics/json/
     output_filename: pharmacogenomics.json.gz
     path: pharmacogenomics-inputs
 pppevidence:


### PR DESCRIPTION
The location of the pharmacogenomics dataset has changed. As the EVA provided dataset needs to be patched by the data team, the resulting dataset is located in an other bucket. 