### PR TITLE
add crispr brain screens data fetcher

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -145,8 +145,6 @@ steps:
   evidence:
     - name: explode ot_curation files
       foreach:
-        - mappings/biosystem/depmap_uberon_mapping.csv
-        - gene_burden/curated_evidence.tsv
         - mappings/disease/brain_crispr_studies.tsv
       do:
         - name: copy ${each}
@@ -208,8 +206,7 @@ steps:
       destination: input/evidence/crispr.json.gz
 
     - name: crispr_brain fetch
-      destination_screens: input/evidence/crispr_screens/brain_screens.json.gz
-      destination_studies_dir: input/evidence/crispr_screens/brain_studies
+      destination: input/evidence/crispr_screens
       api_url: https://crisprbrain.org/api/screens
       client_id: 92f263647c43525d3e4f181aa7e348f26e32129c0f827321d9261cc9765c56c0
       study_prefix_url: https://storage.googleapis.com/crisprbrain.appspot.com/api-data/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "PIS"
-version = "25.2.8"
+version = "25.2.2"
 description = "Open Targets Pipeline Input Stage"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -11,6 +11,7 @@ dependencies = [
   "jq==1.8.0",
   "loguru==0.7.3",
   "opentargets-otter>=25.0.2",
+  "requests>=2.32.4",
 ]
 
 [tool.uv]

--- a/src/pis/tasks/crispr_brain.py
+++ b/src/pis/tasks/crispr_brain.py
@@ -7,13 +7,12 @@ per-study hit lists (CSV.gz).
 from __future__ import annotations
 
 import gzip
-import http.client as http_client
-import io
 import json
 from pathlib import Path
 from typing import Any, Self
-from urllib.parse import quote, urlencode, urlparse
+from urllib.parse import quote
 
+import requests
 from loguru import logger
 from otter.manifest.model import Artifact
 from otter.storage import get_remote_storage
@@ -21,6 +20,9 @@ from otter.task.model import Spec, Task, TaskContext
 from otter.task.task_reporter import report
 from otter.util.errors import OtterError
 from otter.util.fs import check_destination
+from otter.validators import v
+
+from pis.validators.crispr_brain import at_least_one_file_exist
 
 
 class CrisprBrainError(OtterError):
@@ -31,20 +33,18 @@ class CrisprBrainSpec(Spec):
     """Configuration for the CRISPR Brain fetch task.
 
     Custom fields:
-        - destination_screens (str): Path to save the API response (JSON.GZ).
-        - destination_studies_dir (str): Directory to save per-study CSV.GZ files.
+        - destination (str): Path to save files to.
         - api_url (str): Full URL for the screens endpoint.
         - client_id (str): API client identifier.
         - study_prefix_url (str): Base URL for per-study CSV.GZ files.
         - validate_version (int | None): If provided, ensure API __version matches.
     """
 
-    destination_screens: str
-    destination_studies_dir: str
-    api_url: str = 'https://crisprbrain.org/api/screens'
-    client_id: str = '92f263647c43525d3e4f181aa7e348f26e32129c0f827321d9261cc9765c56c0'
-    study_prefix_url: str = 'https://storage.googleapis.com/crisprbrain.appspot.com/api-data/'
-    validate_version: int | None = 1
+    destination: str
+    api_url: str
+    client_id: str
+    study_prefix_url: str
+    validate_version: int | None
 
 
 class CrisprBrain(Task):
@@ -55,161 +55,97 @@ class CrisprBrain(Task):
         self.spec: CrisprBrainSpec
 
         # Resolve local destinations
-        self.screens_local_path: Path = context.config.work_path / spec.destination_screens
-        self.studies_local_dir: Path = context.config.work_path / spec.destination_studies_dir
+        self.screens_local_path: Path = context.config.work_path / spec.destination / 'brain_screens.json.gz'
+        self.studies_local_path = context.config.work_path / spec.destination / 'brain_studies'
 
-        # Resolve remote destinations if configured
-        self.screens_remote_uri: str | None = None
-        self.studies_remote_uri: str | None = None
+        # Resolve remote destinations if release_uri is configured
+        self.screens_remote_uri = None
+        self.studies_remote_uri = None
         if context.config.release_uri:
-            self.screens_remote_uri = f'{context.config.release_uri}/{spec.destination_screens}'
-            self.studies_remote_uri = f'{context.config.release_uri}/{spec.destination_studies_dir}'
+            self.screens_remote_uri = f'{context.config.release_uri}/{spec.destination}/brain_screens.json.gz'
+            self.studies_remote_uri = f'{context.config.release_uri}/{spec.destination}/brain_studies'
 
     def _post_screens(self) -> bytes:
         """POST to screens endpoint and return raw gzipped content."""
-        payload = urlencode({'client_id': self.spec.client_id}).encode()
-        parsed = urlparse(self.spec.api_url)
-        if parsed.scheme not in {'https', 'http'} or not parsed.netloc:
-            raise CrisprBrainError(f'invalid api_url: {self.spec.api_url}')
-        connection_class = http_client.HTTPSConnection if parsed.scheme == 'https' else http_client.HTTPConnection
-        path = parsed.path or '/'
-        if parsed.query:
-            path = f'{path}?{parsed.query}'
-
-        try:
-            conn = connection_class(parsed.netloc, timeout=60)
-            headers = {'Content-Type': 'application/x-www-form-urlencoded'}
-            conn.request('POST', path, body=payload, headers=headers)
-            resp = conn.getresponse()
-            status = resp.status
-            data = resp.read()
-            conn.close()
-        except OSError as e:
-            raise CrisprBrainError(f'error calling screens API: {e}') from e
-
-        if status != 200:
-            raise CrisprBrainError(f'screens API returned HTTP {status}')
-        return data
+        response = requests.post(
+            url=self.spec.api_url,
+            data={'client_id': self.spec.client_id},
+            headers={'Content-Type': 'application/x-www-form-urlencoded'},
+            timeout=60,
+        )
+        response.raise_for_status()
+        return response.content
 
     @staticmethod
     def _extract_study_ids_from_screens_gz(screens_gz: bytes) -> tuple[list[str], dict[str, Any]]:
-        """Extract study identifiers and parsed JSON from gzipped screens payload.
+        """Extract study identifiers and parsed JSON from gzipped screens payload."""
+        json_text = gzip.decompress(screens_gz).decode()
+        screens = json.loads(json_text)
+        return [k for k in screens if not k.startswith('_')], screens
 
-        Returns a tuple of (study_ids, parsed_json_dict).
-        """
-        try:
-            json_text = gzip.decompress(screens_gz).decode()
-            screens = json.loads(json_text)
-        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as e:
-            raise CrisprBrainError(f'error parsing screens payload: {e}') from e
-
-        # Flatten values; each study entry is a dict with metadata
-        # The special keys (like __version) are not dicts and are skipped
-        study_entries: list[dict[str, Any]] = [
-            {**value, **value.get('metadata', {})} for value in screens.values() if isinstance(value, dict)
-        ]
-
-        # Use the same field as the original Spark code: "Screen Name"
-        study_ids = [entry['Screen Name'] for entry in study_entries if 'Screen Name' in entry]
-        return study_ids, screens
-
-    def _download_study_csv_gz(self, study_id: str, destination: Path) -> None:
-        url = f'{self.spec.study_prefix_url}{quote(study_id)}.csv.gz'
-        parsed = urlparse(url)
-        if parsed.scheme not in {'https', 'http'} or not parsed.netloc:
-            raise CrisprBrainError(f'invalid study URL: {url}')
-        connection_class = http_client.HTTPSConnection if parsed.scheme == 'https' else http_client.HTTPConnection
-        path = parsed.path or '/'
-        if parsed.query:
-            path = f'{path}?{parsed.query}'
-        try:
-            conn = connection_class(parsed.netloc, timeout=60)
-            conn.request('GET', path)
-            resp = conn.getresponse()
-            status = resp.status
-            data = resp.read()
-            conn.close()
-        except OSError as e:
-            raise CrisprBrainError(f'error downloading study {study_id}: {e}') from e
-        if status != 200:
-            raise CrisprBrainError(f'study file for {study_id} returned HTTP {status}')
-
-        destination.parent.mkdir(parents=True, exist_ok=True)
-        try:
-            destination.write_bytes(data)
-        except OSError as e:
-            raise CrisprBrainError(f'error writing study {study_id} to {destination}: {e}') from e
+    def _download_study_csv_gz(self, session: requests.Session, study_id: str, destination: Path) -> None:
+        logger.debug(f'downloading study {study_id} to {destination}')
+        check_destination(destination, delete=True)
+        response = session.get(f'{self.spec.study_prefix_url}{quote(study_id)}.csv.gz', timeout=60)
+        response.raise_for_status()
+        destination.write_bytes(response.content)
 
     @report
     def run(self) -> Self:
         # Prepare destinations
-        check_destination(self.screens_local_path, delete=True)
-        self.studies_local_dir.mkdir(parents=True, exist_ok=True)
+        check_destination(self.studies_local_path, delete=True)
 
-        logger.debug('requesting CRISPR Brain screens payload')
+        logger.debug('requesting crispr brain screens payload')
         screens_gz = self._post_screens()
 
-        # Optionally validate API version
         study_ids, screens_dict = self._extract_study_ids_from_screens_gz(screens_gz)
         logger.info(f'found {len(study_ids)} studies in screens payload')
 
+        # Optionally validate API version
         if self.spec.validate_version is not None:
             version = int(screens_dict.get('__version', -1))
             if version != int(self.spec.validate_version):
-                raise CrisprBrainError(
-                    f"API versions don't match: expected {self.spec.validate_version}, got {version}"
-                )
+                raise CrisprBrainError(f'api version mismatch: expected {self.spec.validate_version}, got {version}')
 
         # Save the raw gzipped screens payload
-        try:
-            self.screens_local_path.write_bytes(screens_gz)
-        except OSError as e:
-            raise CrisprBrainError(f'error writing screens file: {e}') from e
+        self.screens_local_path.write_bytes(screens_gz)
 
         # Download each study CSV.gz
+        session = requests.session()
         for study_id in study_ids:
-            study_path = self.studies_local_dir / f'{study_id}.csv.gz'
-            self._download_study_csv_gz(study_id, study_path)
+            self._download_study_csv_gz(session, study_id, self.studies_local_path / f'{study_id}.csv.gz')
 
         logger.debug('downloaded all study files')
 
         # Upload results if remote storage configured
-        if self.screens_remote_uri:
+        if self.context.config.release_uri:
+            logger.debug(f'uploading screens to {self.screens_remote_uri}')
             remote_storage = get_remote_storage(self.screens_remote_uri)
             remote_storage.upload(self.screens_local_path, self.screens_remote_uri)
 
-        if self.studies_remote_uri:
+            logger.debug(f'uploading {len(study_ids)} study files to {self.studies_remote_uri}')
             remote_storage = get_remote_storage(self.studies_remote_uri)
             # upload each file under the directory
-            for file_path in self.studies_local_dir.glob('*.csv.gz'):
-                rel_name = file_path.name
-                remote_storage.upload(file_path, f'{self.studies_remote_uri}/{rel_name}')
+            for file_path in self.studies_local_path.glob('*.csv.gz'):
+                logger.debug(f'uploading {file_path.name}')
+                remote_storage.upload(file_path, f'{self.studies_remote_uri}/{file_path.name}')
 
         self.artifacts = [
             Artifact(
                 source=self.spec.api_url,
                 destination=(self.screens_remote_uri or str(self.screens_local_path)),
             ),
-            Artifact(
-                source=f'{self.spec.study_prefix_url}{{studyId}}.csv.gz',
-                destination=(self.studies_remote_uri or str(self.studies_local_dir)),
-            ),
+            *[
+                Artifact(
+                    source=f'{self.spec.study_prefix_url}{study_id}.csv.gz',
+                    destination=f'{self.studies_remote_uri or str(self.studies_local_path)}/{study_id}.csv.gz',
+                )
+                for study_id in study_ids
+            ],
         ]
         return self
 
     @report
     def validate(self) -> Self:
-        # Basic validation: ensure files exist and are readable
-        try:
-            # screens file must be gzipped json
-            raw = self.screens_local_path.read_bytes()
-            with gzip.GzipFile(fileobj=io.BytesIO(raw)) as gz:
-                json.load(io.TextIOWrapper(gz))
-        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as e:
-            raise CrisprBrainError(f'validation failed for screens file: {e}') from e
-
-        # at least one study file must exist
-        if not any(self.studies_local_dir.glob('*.csv.gz')):
-            raise CrisprBrainError('no study files were downloaded')
-
+        v(at_least_one_file_exist, self.studies_local_path, '*.csv.gz')
         return self

--- a/src/pis/validators/crispr_brain.py
+++ b/src/pis/validators/crispr_brain.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+from loguru import logger
+
+
+def at_least_one_file_exist(path: Path, glob: str) -> bool:
+    """Check if at least one file exists in the given directory matching the glob pattern.
+
+    :param path: The directory path to check for files.
+    :type path: Path
+    :param glob: The glob pattern to match files (e.g., '*.csv.gz').
+    :type glob: Path
+
+    :return: True if at least one file exists, False otherwise.
+    :rtype: bool
+    """
+    logger.debug(f'checking if at least one file exists like {glob} in {path}')
+
+    return len(list(path.glob(glob))) > 0

--- a/uv.lock
+++ b/uv.lock
@@ -530,13 +530,14 @@ wheels = [
 
 [[package]]
 name = "pis"
-version = "25.2.8"
+version = "25.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "elasticsearch" },
     { name = "jq" },
     { name = "loguru" },
     { name = "opentargets-otter" },
+    { name = "requests" },
 ]
 
 [package.optional-dependencies]
@@ -573,6 +574,7 @@ requires-dist = [
     { name = "opentargets-otter", specifier = ">=25.0.2" },
     { name = "pytest", marker = "extra == 'test'", specifier = "==8.3.4" },
     { name = "pytest-mock", marker = "extra == 'test'", specifier = "==3.14.0" },
+    { name = "requests", specifier = ">=2.32.4" },
     { name = "sphinx", marker = "extra == 'docs'", specifier = ">=8.1.3" },
     { name = "sphinx-autobuild", marker = "extra == 'docs'", specifier = ">=2024.10.3" },
     { name = "sphinx-issues", marker = "extra == 'docs'", specifier = ">=5.0.0" },


### PR DESCRIPTION
Context https://github.com/opentargets/issues/issues/4035

It works

This PR adds a new type of task to PIS because CRISPR Brain screens are retrieved from the CRISPR Brain API payload and I think this was not possible with the current types of tasks. 

I followed the instructions in https://github.com/opentargets/evidence_datasource_parsers/blob/master/modules/BrainCRISPR.py + AI help.

It basically:
1. Fetches all screens metadata with the POST request
2. It downloads each study hits file from GCS


