### PR TITLE
fix: remove deprecated Project Score fetch tasks

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -984,14 +984,6 @@ steps:
       source: https://ftp.ncbi.nlm.nih.gov/gene/DATA/GENE_INFO/Mammalia/Homo_sapiens.gene_info.gz
       destination: input/target/ncbi/Homo_sapiens.gene_info.gz
 
-    - name: copy project score gene identifier
-      source: https://cog.sanger.ac.uk/cmp/download/gene_identifiers_latest.csv.gz
-      destination: input/target/project-scores/gene_identifiers_latest.csv.gz
-
-    - name: copy project score essentiality matrix
-      source: https://cog.sanger.ac.uk/cmp/download/essentiality_matrices.zip
-      destination: input/target/project-scores/essentiality_matrices.zip
-
     - name: copy reactome ensembl2reactome
       source: https://reactome.org/download/current/Ensembl2Reactome.txt
       destination: input/target/reactome/Ensembl2Reactome.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "PIS"
-version = "26.06.4"
+version = "26.06.5"
 description = "Open Targets Pipeline Input Stage"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"


### PR DESCRIPTION
## Summary

Project Score has been deprecated upstream. Stop fetching the two files that fed the (now removed) target dbXrefs pipeline in pts:

- `https://cog.sanger.ac.uk/cmp/download/gene_identifiers_latest.csv.gz`
- `https://cog.sanger.ac.uk/cmp/download/essentiality_matrices.zip`

The Sanger Cell Model Passport download (`model_list_latest.csv.gz`, used by the surviving Project Score v2 CRISPR evidence parser) is untouched.

Companion PRs:
- pts: opentargets/pts#138 (drops `_build_project_scores` and the matching source entries)
- orchestration: to follow (mirror both changes + drop `project-scores/` from the validate fixture)

Refs opentargets/issues#4367
