### PR TITLE
feat(drug): download aact_extraction_batch_results in the drug step

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -175,6 +175,13 @@ steps:
       source: https://ftp.ebi.ac.uk/pub/databases/chembl/UniChem/data/wholeSourceMapping/src_id1/src1src2.txt.gz
       destination: input/drug/drugbank.csv.gz
 
+    # AACT clinical-trial batch extraction — a standalone source consumed by
+    # chembl_molecule (and clinical_report). Downloaded in the drug step so
+    # chembl_molecule's existing pis_drug dependency covers it.
+    - name: copy_many aact extraction batch results
+      sources: gs://ot-team/irene/clinical_mining/aact_extraction_batch_result/output/*
+      destination: input/clinical_report/aact_extraction_batch_results
+
     - name: elasticsearch chembl drug warning
       url: https://www.ebi.ac.uk/chembl/elk/es
       destination: input/drug/chembl_drug_warning.jsonl

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "PIS"
-version = "26.06.5"
+version = "26.06.6"
 description = "Open Targets Pipeline Input Stage"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"


### PR DESCRIPTION
## Summary

Download the AACT clinical-trial batch extraction (`aact_extraction_batch_results`) in the **drug** step.

This input feeds `chembl_molecule` (opentargets/pts#142, tracking issue opentargets/issues#4414). It lives in its own standalone source — `gs://ot-team/irene/clinical_mining/aact_extraction_batch_result/output` — so the drug step copies it to `input/clinical_report/aact_extraction_batch_results/` (the path both `chembl_molecule` and `clinical_report` read).

Because `chembl_molecule` already depends on `pis_drug`, this needs **no** new `pts_chembl_molecule → pis_clinical_report` DAG edge.

## What changed

`config.yaml`, drug step only — adds a `copy_many` that copies `…/aact_extraction_batch_result/output/*` → `input/clinical_report/aact_extraction_batch_results/`. The clinical_report step is unchanged (the batch is no longer nested under its input tree).

## Companion changes

- PTS: opentargets/pts#142 — `chembl_molecule` source path unchanged.
- Orchestration: opentargets/orchestration#207 — mirrors this PIS change; DAG dependencies unchanged.
