### PR TITLE
build: bump Python base off stale 3.13.1 patch -> 3.13 line

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 #
 # docker run -v /path/to/credentials.json:/app/credentials.json -e GOOGLE_APPLICATION_CREDENTIALS=/app/credentials.json pis -s so
 
-FROM python:3.13.1-alpine3.21
+FROM python:3.13-alpine3.21
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/uv
 
 ADD . /app

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "PIS"
-version = "26.06.6"
+version = "26.06.7"
 description = "Open Targets Pipeline Input Stage"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"


### PR DESCRIPTION
## Summary

Relax the Docker base image pin from the exact patch `python:3.13.1-alpine3.21` to the `python:3.13-alpine3.21` minor line.

This addresses a security-audit lifecycle finding (CWE-1104, *Use of Unmaintained Third Party Components* — Low). Python 3.13 itself is still supported (bugfixes through ~2029), but `3.13.1` is a December 2024 patch release. Pinning that exact patch froze the runtime on a 2024 build and left it missing ~13 subsequent CPython patch releases of security and bug fixes. Tracking the `3.13` minor line means rebuilds automatically pick up the latest 3.13 patch, so this drift never recurs while staying on the same supported minor.

## Scope / verification

- Single-line change to `Dockerfile` (base image tag only); nothing else touched.
- Application dependencies remain pinned via `uv.lock` (`uv sync --frozen`), so build reproducibility of the app deps is unaffected.
- `python:3.13-alpine3.21` is a standard Docker official image variant. Confirmed resolvable via `docker manifest inspect python:3.13-alpine3.21` (returns a valid multi-arch OCI image index).
