### PR TITLE
feat(spark_nlp_jars): stage spark-nlp fat jar into the release bucket

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -16,8 +16,19 @@ scratchpad:
   probes_drugs_version: '02_2025'
   gnomad_version: '4.1'
   gtex_version: '10'
+  spark_nlp_version: '6.1.3'
 
 steps:
+  ##################################################################################################
+  #: SPARK-NLP JARS STEP :##########################################################################
+  # Stage the Spark-NLP fat jar into the release bucket so the pts Dataproc cluster can load it via
+  # spark.jars instead of resolving the package from Maven Central on every spark-submit.
+  # See opentargets/issues#4453.
+  spark_nlp_jars:
+    - name: copy spark-nlp fat jar
+      source: https://s3.amazonaws.com/auxdata.johnsnowlabs.com/public/jars/spark-nlp-assembly-${spark_nlp_version}.jar
+      destination: input/jars/spark-nlp-assembly-${spark_nlp_version}.jar
+
   ##################################################################################################
   #: BASELINE EXPRESSION STEP :#####################################################################
   baseline_expression_raw:


### PR DESCRIPTION
## What

Add a `spark_nlp_jars` PIS step that copies the John Snow Labs Spark-NLP **fat
jar** into the release bucket:

```yaml
spark_nlp_jars:
  - name: copy spark-nlp fat jar
    source: https://s3.amazonaws.com/auxdata.johnsnowlabs.com/public/jars/spark-nlp-assembly-${spark_nlp_version}.jar
    destination: input/jars/spark-nlp-assembly-${spark_nlp_version}.jar
```

(+ a `spark_nlp_version` scratchpad entry.)

## Why

Part of the fix for opentargets/issues#4453. The `pts` Dataproc cluster set
`spark:spark.jars.packages=spark-nlp` at cluster level, so **every**
`spark-submit` re-ran Ivy dependency resolution against Maven Central — putting
Central on the critical path of every PTS step (measured: 17/17 jobs on run
`up-pts-38bc6`, ~3–7 s each).

Staging the pre-resolved fat jar into the release bucket lets the cluster load
Spark-NLP via `spark.jars` (a single in-region GCS localization, no resolution,
no Maven Central). Doing it as a PIS step means the version is pinned in config
and the jar travels with each release.

## Coordination

This is the PIS half. The consuming changes live in:
- **opentargets/orchestration** — `clusters.yaml` `pts` cluster points
  `spark.jars` at `{{release_uri}}/input/jars/spark-nlp-assembly-{{spark_nlp_version}}.jar`,
  and the `pts` cluster's creation is gated on the `pis_spark_nlp_jars` step.
- **opentargets/pts#146** — sets `spark.jars.packages` in-app (post-SparkSubmit,
  no Ivy) so OnToma's guard still passes.

Note: orchestration runs its own copy of the PIS config
(`dags/config/pis.yaml`); the same step is added there in the orchestration PR.
This change keeps the canonical PIS config in sync and enables local
`uv run pis --step spark_nlp_jars`.

Refs opentargets/issues#4453
